### PR TITLE
propagationPolicy deletes Pods in the background on Job deletion

### DIFF
--- a/cli/aws_orbit/remote_files/cdk/team_builders/stepfunctions.py
+++ b/cli/aws_orbit/remote_files/cdk/team_builders/stepfunctions.py
@@ -264,9 +264,7 @@ class StateMachineBuilder:
                     "Api": "batch",
                     "Path": "/jobs/{job}",
                     "PathArgs": {"job": sfn.JsonPath.string_at("$.RunJobResult.metadata.name")},
-                    "QueryParameters": {
-                        "propagationPolicy": ["Background"]
-                    },
+                    "QueryParameters": {"propagationPolicy": ["Background"]},
                 }
             ),
             result_path="$.DeleteJobResult",


### PR DESCRIPTION
### Description:

default `propagationPolicy` was "Orphan" which was leaving Pods (and their Fargate resources) around when the Job was deleted.

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
