### PR TITLE
Fix manifest after teams destroy.

### DIFF
--- a/cli/aws_orbit/remote_files/teams.py
+++ b/cli/aws_orbit/remote_files/teams.py
@@ -163,7 +163,6 @@ def destroy(manifest: "Manifest", team_manifest: "TeamManifest") -> None:
                 args = ["manifest", manifest.filename, team_manifest.name]
             else:
                 args = ["env", manifest.name, team_manifest.name]
-
             cdk.destroy(
                 manifest=manifest,
                 stack_name=team_manifest.stack_name,
@@ -175,3 +174,5 @@ def destroy(manifest: "Manifest", team_manifest: "TeamManifest") -> None:
 def destroy_all(manifest: "Manifest") -> None:
     for team_manifest in manifest.teams:
         destroy(manifest=manifest, team_manifest=team_manifest)
+    manifest.teams = []
+    manifest.write_manifest_ssm()


### PR DESCRIPTION
### Description:

Fix manifest after teams destroy.

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
