### PR TITLE
fix image build.  The path was wrong and there was context type missing.

### DIFF
--- a/cli/aws_orbit/commands/image.py
+++ b/cli/aws_orbit/commands/image.py
@@ -174,7 +174,7 @@ def build_image(
         build_args = [] if build_args is None else build_args
         buildspec = codebuild.generate_spec(
             context=context,
-            plugins=True,
+            plugins=False,
             cmds_build=[
                 f"orbit remote --command build_image {env} {name} {script_str} {teams_str} {' '.join(build_args)}"
             ],

--- a/cli/aws_orbit/docker.py
+++ b/cli/aws_orbit/docker.py
@@ -151,6 +151,10 @@ def deploy_image_from_source(
     build_args: Optional[List[str]] = None,
 ) -> None:
     _logger.debug("Adding CodeArtifact login to build environment, used by Dockerfile")
+    if not os.path.exists(dir):
+        bundle_dir = os.path.join("bundle", dir)
+        if os.path.exists(bundle_dir):
+            dir = bundle_dir
     if context.codeartifact_domain and context.codeartifact_repository:
         ca_domain: str = context.codeartifact_domain
         ca_repo: str = context.codeartifact_repository

--- a/cli/aws_orbit/remote_files/build.py
+++ b/cli/aws_orbit/remote_files/build.py
@@ -13,19 +13,16 @@
 #    limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, List, Optional, Tuple, cast
+from typing import List, Optional, Tuple, cast
 
 from boto3 import client
 
 from aws_orbit import docker, plugins, sh
-from aws_orbit.models.context import ContextSerDe
+from aws_orbit.models.context import Context, ContextSerDe, TeamContext
+from aws_orbit.models.manifest import ImageManifest
 from aws_orbit.remote_files import teams as team_utils
 from aws_orbit.remote_files.env import DEFAULT_IMAGES, DEFAULT_ISOLATED_IMAGES
 from aws_orbit.utils import boto3_client
-
-if TYPE_CHECKING:
-    from aws_orbit.models.context import Context, TeamContext
-    from aws_orbit.models.manifest import ImageManifest
 
 _logger: logging.Logger = logging.getLogger(__name__)
 

--- a/cli/aws_orbit/services/codebuild.py
+++ b/cli/aws_orbit/services/codebuild.py
@@ -254,7 +254,6 @@ def generate_spec(
         install.append("cp ~/.config/pip/pip.conf .")
 
     install.append("pwd")
-    install.append("find . -name '*.yaml'")
     # Orbit Workbench CLI
     install.append(f"pip install aws-orbit=={__version__}")
 


### PR DESCRIPTION
### Description:

fix image build.  The path was wrong and there was context type missing.

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
