### PR TITLE
don't load plugins in build_images. plugins do not change an image

### DIFF
--- a/cli/aws_orbit/remote_files/build.py
+++ b/cli/aws_orbit/remote_files/build.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Tuple, cast
 
 from boto3 import client
 
-from aws_orbit import docker, plugins, sh
+from aws_orbit import docker, sh
 from aws_orbit.models.context import Context, ContextSerDe, TeamContext
 from aws_orbit.models.manifest import ImageManifest
 from aws_orbit.remote_files import teams as team_utils


### PR DESCRIPTION
### Description:

removed load_plugins for build image

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
