### PR TITLE
fix image repo used by controller, also kubespawner timeout

### DIFF
--- a/images/jupyter-hub/jupyterhub_config.py
+++ b/images/jupyter-hub/jupyterhub_config.py
@@ -53,7 +53,7 @@ c.Spawner.cmd = ["/usr/local/bin/start-singleuser.sh", "-e", "CHOWN_EXTRA=/home/
 c.Spawner.args = [
     "--SingleUserServerApp.default_url=/lab",
 ]
-c.KubeSpawner.start_timeout = 360
+c.KubeSpawner.start_timeout = 600
 c.KubeSpawner.common_labels = {"orbit/node-type": "ec2", "orbit/attach-security-group": "yes"}
 c.KubeSpawner.namespace = TEAM
 c.KubeSpawner.environment = {

--- a/sdk/aws_orbit_sdk/controller.py
+++ b/sdk/aws_orbit_sdk/controller.py
@@ -552,7 +552,7 @@ def _create_eks_job_spec(taskConfiguration: dict, labels: Dict[str, str], team_c
 def resolve_image(__CURRENT_TEAM_MANIFEST__, profile):
     if not profile or "kubespawner_override" not in profile or "image" not in profile["kubespawner_override"]:
         repository = __CURRENT_TEAM_MANIFEST__["FinalImageAddress"]
-        image = f"{repository}:latest"
+        image = f"{repository}"
     else:
         image = profile["kubespawner_override"]["image"]
     return image


### PR DESCRIPTION
### Description:

- fix: controller image repo
- fix: kubespawner timeout (increased)

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
