### PR TITLE
removing hardcoded env params

### DIFF
--- a/samples/notebooks/I-Image/Example-1-simple.ipynb
+++ b/samples/notebooks/I-Image/Example-1-simple.ipynb
@@ -318,7 +318,7 @@
    "source": [
     "%%time\n",
     "\n",
-    "output = !orbit build image -e dev-env -d $pwd -n $image_name\n",
+    "output = !orbit build image -e $env_name -d $pwd -n $image_name\n",
     "output"
    ]
   },

--- a/samples/notebooks/I-Image/Example-2-spark.ipynb
+++ b/samples/notebooks/I-Image/Example-2-spark.ipynb
@@ -299,7 +299,7 @@
    "source": [
     "%%time\n",
     "\n",
-    "output = !orbit build image -e dev-env -d $pwd -n $image_name\n",
+    "output = !orbit build image -e $env_name -d $pwd -n $image_name\n",
     "output"
    ]
   },


### PR DESCRIPTION
### Description:

These notebooks have hardcoded environment params that cause tests to fail if your foundation is not named dev-env

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
