### PR TITLE
always set to manifest value; fix teams permissions

### DIFF
--- a/cli/aws_orbit/models/context.py
+++ b/cli/aws_orbit/models/context.py
@@ -419,6 +419,7 @@ class ContextSerDe(Generic[T, V]):
                 policies=manifest.policies,
                 install_ssm_agent=manifest.install_ssm_agent,
             )
+        context.install_ssm_agent = manifest.install_ssm_agent
         ContextSerDe.fetch_toolkit_data(context=context)
         ContextSerDe.dump_context_to_ssm(context=context)
         return context

--- a/cli/aws_orbit/remote_files/cdk/team_builders/iam.py
+++ b/cli/aws_orbit/remote_files/cdk/team_builders/iam.py
@@ -69,8 +69,9 @@ class IamBuilder:
                 ),
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
-                    actions=["s3:ListObject*", "s3:GetObject*"],
+                    actions=["s3:ListObjects*", "s3:GetObject*"],
                     resources=[
+                        f"arn:{partition}:s3:::{context.toolkit.s3_bucket}",
                         f"arn:{partition}:s3:::{context.toolkit.s3_bucket}/samples/*",
                         f"arn:{partition}:s3:::{context.toolkit.s3_bucket}/teams/{team_name}/*",
                     ],


### PR DESCRIPTION
### Description:

- always set install_ssm_agent to manifest value
- fix teams toolkit bucket permissions

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
