### PR TITLE
rollback toolkit permissions; use utils for template on ssm manifest

### DIFF
--- a/cli/aws_orbit/remote_files/cdk/team_builders/iam.py
+++ b/cli/aws_orbit/remote_files/cdk/team_builders/iam.py
@@ -69,7 +69,7 @@ class IamBuilder:
                 ),
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
-                    actions=["s3:ListObjects*", "s3:GetObject*"],
+                    actions=["s3:List*", "s3:Get*"],
                     resources=[
                         f"arn:{partition}:s3:::{context.toolkit.s3_bucket}",
                         f"arn:{partition}:s3:::{context.toolkit.s3_bucket}/samples/*",

--- a/cli/aws_orbit/remote_files/kubectl.py
+++ b/cli/aws_orbit/remote_files/kubectl.py
@@ -137,10 +137,7 @@ def _ssm_agent_installer(output_path: str, context: "Context") -> None:
         content: str = file.read()
     content = utils.resolve_parameters(
         content,
-        dict(
-            ssm_agent_installer_image=ssm_agent_installer_image,
-            pause_image=pause_image
-        ),
+        dict(ssm_agent_installer_image=ssm_agent_installer_image, pause_image=pause_image),
     )
     with open(output, "w") as file:
         file.write(content)

--- a/cli/aws_orbit/remote_files/kubectl.py
+++ b/cli/aws_orbit/remote_files/kubectl.py
@@ -135,8 +135,12 @@ def _ssm_agent_installer(output_path: str, context: "Context") -> None:
 
     with open(input, "r") as file:
         content: str = file.read()
-    content = content.replace("$", "").format(
-        ssm_agent_installer_image=ssm_agent_installer_image, pause_image=pause_image
+    content = utils.resolve_parameters(
+        content,
+        dict(
+            ssm_agent_installer_image=ssm_agent_installer_image,
+            pause_image=pause_image
+        ),
     )
     with open(output, "w") as file:
         file.write(content)


### PR DESCRIPTION
### Description:

- rollback toolkit permissions
- use utils for template on ssm manifest

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
