### PR TITLE
fixed the hash generated in Uppercase which breaks the toolkit bucket…

### DIFF
--- a/cli/aws_orbit/commands/deploy.py
+++ b/cli/aws_orbit/commands/deploy.py
@@ -104,7 +104,7 @@ def deploy_toolkit(
             )
             credential_exist = True
     else:
-        context.toolkit.deploy_id = "".join(random.choice(string.ascii_letters) for i in range(6))
+        context.toolkit.deploy_id = ("".join(random.choice(string.ascii_letters) for i in range(6)).lower())
         if credential_required and not credential_received:
             username, password = _request_dockerhub_credential(msg_ctx=msg_ctx)
             credential_exist = False


### PR DESCRIPTION
fixed the hash generated in `Uppercase` which breaks the toolkit bucket creation.

### Description:

**Replace with description of the changes**

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
