### PR TITLE
changing references to sm-operator image to our public repo

### DIFF
--- a/plugins/sm-operator/sm-operator/values.yaml
+++ b/plugins/sm-operator/sm-operator/values.yaml
@@ -9,5 +9,5 @@ serviceAccountName: ${team}
 team: ${team} 
 
 image:
-  repository: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s
-  tag: v1
+  repository: public.ecr.aws/v3o4w1g6/aws-orbit-workbench/amazon/amazon-sagemaker-operator-for-k8s
+  tag: latest


### PR DESCRIPTION
### Description:
Title says it all - sagemaker-operater dependency image in our public ECR, this is a change to reference that repo

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
