### PR TITLE
Modify where samples are copited...to /efs, remvoed vscode copy command

### DIFF
--- a/images/utility-data/src/utility-data/stage_all_data.sh
+++ b/images/utility-data/src/utility-data/stage_all_data.sh
@@ -21,7 +21,7 @@ env=$1
 
 python3 /opt/orbit/scripts/stage_regression_data.py $env
 bash /opt/orbit/scripts/stage_samples_data.sh
-bash /opt/orbit/scripts/stage_vscode_extensions.sh
+#bash /opt/orbit/scripts/stage_vscode_extensions.sh
 
 
 

--- a/images/utility-data/src/utility-data/stage_samples_data.sh
+++ b/images/utility-data/src/utility-data/stage_samples_data.sh
@@ -19,7 +19,7 @@
 set -ex
 
 src_samples_data='/opt/orbit/samples/'
-target_samples_data='/home/jovyan/shared/samples'
+target_samples_data='/efs/samples'
 
 echo "Staging samples data on filsystem"
 if ! [ -d $target_samples_data ]; then

--- a/images/utility-data/src/utility-data/stage_vscode_extensions.sh
+++ b/images/utility-data/src/utility-data/stage_vscode_extensions.sh
@@ -19,7 +19,7 @@
 set -ex
 
 src_vscode_data='/opt/orbit/data/vscode/extensions/'
-target_vscode_data='/home/jovyan/shared/drivers'
+target_vscode_data='/efs/drivers'
 
 if ! [ -d $target_vscode_data ]; then
   mkdir -p $target_vscode_data


### PR DESCRIPTION
### Description:

Changed where samples are copied onto the shared drive (to /efs/shared).  Remove call to copy vscode.

NOTE: image already manually pushed to public ecr

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
