### PR TITLE
retrieve all pod_settings on each request

### DIFF
--- a/images/admission-controller/src/aws_orbit_admission_controller/pod.py
+++ b/images/admission-controller/src/aws_orbit_admission_controller/pod.py
@@ -314,8 +314,12 @@ def process_request(logger: logging.Logger, request: Dict[str, Any]) -> Any:
         logger.info("No orbit/team label found on namespace: %s", request["namespace"])
         return get_response(uid=request["uid"])
 
+    # team_pod_settings = filter_pod_settings(
+    #     logger=logger, pod_settings=ORBIT_SYSTEM_POD_SETTINGS, namespace=team_namespace, pod=pod
+    # )
+    # Temporarily retrieve all pod_settings on each request until caching is fixed
     team_pod_settings = filter_pod_settings(
-        logger=logger, pod_settings=ORBIT_SYSTEM_POD_SETTINGS, namespace=team_namespace, pod=pod
+        logger=logger, pod_settings=get_pod_settings(client=client), namespace=team_namespace, pod=pod
     )
     logger.debug("filtered podsettings: %s", team_pod_settings)
 


### PR DESCRIPTION
…s fixed

### Description:

Temporarily retrieve all pod_settings on each request until caching is fixed

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
