### PR TITLE
CVE-2021-33503 - patch urllib3

### DIFF
--- a/plugins/code_commit/requirements-dev.txt
+++ b/plugins/code_commit/requirements-dev.txt
@@ -235,7 +235,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/custom_cfn/requirements-dev.txt
+++ b/plugins/custom_cfn/requirements-dev.txt
@@ -177,7 +177,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/emr_on_eks/requirements-dev.txt
+++ b/plugins/emr_on_eks/requirements-dev.txt
@@ -256,7 +256,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/hello_world/requirements-dev.txt
+++ b/plugins/hello_world/requirements-dev.txt
@@ -255,7 +255,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/lustre/requirements-dev.txt
+++ b/plugins/lustre/requirements-dev.txt
@@ -177,7 +177,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/overprovisioning/requirements-dev.txt
+++ b/plugins/overprovisioning/requirements-dev.txt
@@ -177,7 +177,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/ray/requirements-dev.txt
+++ b/plugins/ray/requirements-dev.txt
@@ -177,7 +177,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/redshift/requirements-dev.txt
+++ b/plugins/redshift/requirements-dev.txt
@@ -716,7 +716,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/sm-operator/requirements-dev.txt
+++ b/plugins/sm-operator/requirements-dev.txt
@@ -248,7 +248,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/team_script_launcher/requirements-dev.txt
+++ b/plugins/team_script_launcher/requirements-dev.txt
@@ -177,7 +177,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes

--- a/plugins/voila/requirements-dev.txt
+++ b/plugins/voila/requirements-dev.txt
@@ -177,7 +177,7 @@ typing-extensions==3.7.4.3
     #   typing-inspect
 typing-inspect==0.6.0
     # via marshmallow-dataclass
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   kubernetes


### PR DESCRIPTION
Impact
When provided with a URL containing many @ characters in the authority component the authority regular expression exhibits catastrophic backtracking causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect.

Patches
The issue has been fixed in urllib3 v1.26.5.

CVE-2021-33503


----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
