### PR TITLE
move label_selector to client rather than api

### DIFF
--- a/images/orbit-controller/src/orbit_controller/pod.py
+++ b/images/orbit-controller/src/orbit_controller/pod.py
@@ -15,6 +15,7 @@
 import base64
 import copy
 import logging
+import os
 import re
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, cast
@@ -28,6 +29,13 @@ from orbit_controller import ORBIT_API_GROUP, ORBIT_API_VERSION, dump_resource, 
 
 ORBIT_POD_SETTINGS_CACHE = None
 ORBIT_POD_SETTINGS_STATE = None
+
+
+def _verbosity() -> int:
+    try:
+        return int(os.environ.get("ORBIT_CONTROLLER_LOG_VERBOSITY", "0"))
+    except Exception:
+        return 0
 
 
 def get_podsettings(logger: logging.Logger, client: dynamic.DynamicClient) -> List[Dict[str, Any]]:
@@ -375,7 +383,8 @@ def process_request(logger: logging.Logger, request: Dict[str, Any]) -> Any:
     pod = request["object"]
     modified_pod = copy.deepcopy(pod)
 
-    logger.info("request: %s", request)
+    if _verbosity() > 2:
+        logger.info("request: %s", request)
 
     client = dynamic_client()
     podsettings = get_podsettings(logger=logger, client=client)

--- a/images/orbit-controller/src/orbit_controller/podsetting.py
+++ b/images/orbit-controller/src/orbit_controller/podsetting.py
@@ -117,7 +117,7 @@ def watch(queue: Queue, state: Dict[str, Any]) -> int:  # type: ignore
                 logger.debug("watcher state: %s", state)
                 queue_event = {"type": event["type"], "raw_object": event["raw_object"]}
 
-                labels = queue_event.get("metadata", {}).get("labels", {})
+                labels = event["raw_object"].get("metadata", {}).get("labels", {})
                 if labels.get("orbit/space") == "team" and "orbit/disable-watcher" not in labels:
                     logger.debug(
                         "Queueing PodSetting event for processing type: %s podsetting: %s",

--- a/images/orbit-controller/src/orbit_controller/podsetting.py
+++ b/images/orbit-controller/src/orbit_controller/podsetting.py
@@ -108,7 +108,6 @@ def watch(queue: Queue, state: Dict[str, Any]) -> int:  # type: ignore
 
             kwargs = {
                 "resource_version": state.get("lastResourceVersion", 0),
-                "label_selector": "orbit/space=team,!orbit/disable-watcher",
             }
             for event in api.watch(**kwargs):
                 if _verbosity() > 2:
@@ -117,12 +116,15 @@ def watch(queue: Queue, state: Dict[str, Any]) -> int:  # type: ignore
                 state["lastResourceVersion"] = podsetting.get("metadata", {}).get("resourceVersion", 0)
                 logger.debug("watcher state: %s", state)
                 queue_event = {"type": event["type"], "raw_object": event["raw_object"]}
-                logger.debug(
-                    "Queueing PodSetting event for processing type: %s podsetting: %s",
-                    event["type"],
-                    dump_resource(event["raw_object"]),
-                )
-                queue.put(queue_event)
+
+                labels = queue_event.get("metadata", {}).get("labels", {})
+                if labels.get("orbit/space") == "team" and "orbit/disable-watcher" not in labels:
+                    logger.debug(
+                        "Queueing PodSetting event for processing type: %s podsetting: %s",
+                        event["type"],
+                        dump_resource(event["raw_object"]),
+                    )
+                    queue.put(queue_event)
         except ReadTimeoutError:
             logger.warning(
                 "There was a timeout error accessing the Kubernetes API. Retrying request.",

--- a/plugins/lustre/lustre/charts/team/fsx-storageclass/templates/podsettings.yaml
+++ b/plugins/lustre/lustre/charts/team/fsx-storageclass/templates/podsettings.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Values.team }}
   labels:
     orbit/space: team
+    orbit/disable-watcher: "yes"
     {{- include "fsx-storageclass.labels" . | nindent 4 }}
 spec:
   desc:  Mount FsX Lustre folder {{.Values.folder}}


### PR DESCRIPTION
### Description:

move podsetting watch label_selector to client rather than api

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
