### PR TITLE
changed instanceType from t3 to m5 cuz t3 doesnt have trunk support yet

### DIFF
--- a/cli/aws_orbit/remote_files/eksctl.py
+++ b/cli/aws_orbit/remote_files/eksctl.py
@@ -115,8 +115,8 @@ def generate_manifest(context: "Context", name: str, nodegroups: Optional[List[M
         {
             "name": "env",
             "privateNetworking": True,
-            "instanceType": "t3a.xlarge",
-            "minSize": 1,
+            "instanceType": "m5.large",
+            "minSize": 2,
             "desiredCapacity": 2,
             "maxSize": 4,
             "volumeSize": 64,


### PR DESCRIPTION
### Description:

changed instanceType from t3 to m5 cuz t3 doesnt have trunk support yet
Fixes #679 

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
