### PR TITLE
remove overprovisioning from creator as it is in admin now

### DIFF
--- a/samples/manifests/demo/lake-creator-plugins.yaml
+++ b/samples/manifests/demo/lake-creator-plugins.yaml
@@ -67,9 +67,3 @@
         number_of_nodes: "2"
 -   PluginId: fast_fs_lustre
     Module: lustre
--   PluginId: overprovisioning1
-    Module: overprovisioning
-    Parameters:
-        replicas: 3
-        cpu: 2
-        memory: 4G


### PR DESCRIPTION
### Description:

Looks like overprovisioning plugin was moved to admin...removing the one in creator

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
