### PR TITLE
fix for appending multiple NB_PREFIX env variables when podsetting is…

### DIFF
--- a/images/orbit-controller/src/orbit_controller/pod.py
+++ b/images/orbit-controller/src/orbit_controller/pod.py
@@ -291,11 +291,13 @@ def apply_settings_to_container(
 
     # Extend pod_setting ENV
     if "notebookApp" in ps_spec:
+        # Drop any previous NB_PREFIX env variable
+        ps_spec["env"] = [e for e in ps_spec.get("env", []) if e["name"] not in ["NB_PREFIX"]]
         ps_spec["env"].append(
             {
                 "name": "NB_PREFIX",
                 "value": f"/notebook/{pod.get('metadata', {}).get('namespace')}"
-                f"/{pod.get('metadata', {}).get('labels', {}).get('notebook-name')}/{ps_spec['notebookApp']})",
+                f"/{pod.get('metadata', {}).get('labels', {}).get('notebook-name')}/{ps_spec['notebookApp']}",
             }
         )
 


### PR DESCRIPTION
- fix for appending multiple NB_PREFIX env variables when podsetting is called repeatedly
- fix hanging ")" char


**Replace with description of the changes**

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
