### PR TITLE
fixing refresh token time

### DIFF
--- a/cli/aws_orbit/remote_files/deploy.py
+++ b/cli/aws_orbit/remote_files/deploy.py
@@ -263,8 +263,8 @@ def _update_userpool_client(context: Context) -> None:
         AllowedOAuthScopes=["aws.cognito.signin.user.admin", "email", "openid", "profile"],
         AllowedOAuthFlowsUserPoolClient=True,
         PreventUserExistenceErrors="ENABLED",
-        TokenValidityUnits={"AccessToken": "minutes", "IdToken": "minutes", "RefreshToken": "minutes"},
-        RefreshTokenValidity=1440,
+        TokenValidityUnits={"AccessToken": "minutes", "IdToken": "minutes", "RefreshToken": "days"},
+        RefreshTokenValidity=90,
         AccessTokenValidity=60,
         IdTokenValidity=60,
     )


### PR DESCRIPTION
…ncreasing the refresh token to 90 days.  Thats the longest that the pod can be running in without re-login.

### Description:

**Replace with description of the changes**

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/708

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
