### PR TITLE
added ability to send notebook failure alerts to internal slack channel

### DIFF
--- a/cli/aws_orbit/remote_files/cdk/team_builders/iam.py
+++ b/cli/aws_orbit/remote_files/cdk/team_builders/iam.py
@@ -229,6 +229,7 @@ class IamBuilder:
                     ],
                     resources=[
                         f"arn:{partition}:ssm:{region}:{account}:parameter/orbit/{env_name}/teams/{team_name}/*",
+                        f"arn:{partition}:ssm:{region}:{account}:parameter/Orbit-Slack-Notifications"
                     ],
                 ),
                 iam.PolicyStatement(

--- a/samples/notebooks/Z-Tests/run-admin-regression-notebooks.ipynb
+++ b/samples/notebooks/Z-Tests/run-admin-regression-notebooks.ipynb
@@ -22,7 +22,10 @@
     "import boto3\n",
     "from aws_orbit_sdk import controller\n",
     "from aws_orbit_sdk.common import get_workspace,get_scratch_database\n",
-    "s3 = boto3.client('s3')\n"
+    "from botocore.exceptions import ClientError\n",
+    "s3 = boto3.client('s3')\n",
+    "sns = boto3.client('sns')\n",
+    "ssm = boto3.client('ssm')"
    ]
   },
   {
@@ -623,6 +626,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "\n",
+    "if len(results['failed']) > 0:\n",
+    "    topicArn = ssm.get_parameter(Name=\"Orbit-Slack-Notifications\")[\"Parameter\"][\"Value\"]\n",
+    "    unmar_topicArn = json.loads(topicArn)\n",
+    "    try:\n",
+    "        response = sns.get_topic_attributes(\n",
+    "            TopicArn=unmar_topicArn['TopicArn']\n",
+    "        )\n",
+    "        d={}\n",
+    "        d['message']=results['failed']\n",
+    "        response = sns.publish(\n",
+    "            TopicArn=str(unmar_topicArn['TopicArn']),\n",
+    "            Message=json.dumps({'default': json.dumps(d)}),\n",
+    "            Subject='string',\n",
+    "            MessageStructure='json'\n",
+    "        )\n",
+    "    except ClientError as ex:\n",
+    "        if ex.response['Error']['Code'] == 'NotFoundException':\n",
+    "            print (\"SNS Topic doesnt exist\")\n",
+    "\n",
     "assert len(results['failed']) == 0"
    ]
   },

--- a/samples/notebooks/Z-Tests/run-user-regression-notebooks.ipynb
+++ b/samples/notebooks/Z-Tests/run-user-regression-notebooks.ipynb
@@ -22,7 +22,10 @@
     "import boto3\n",
     "from aws_orbit_sdk import controller\n",
     "from aws_orbit_sdk.common import get_workspace,get_scratch_database\n",
-    "s3 = boto3.client('s3')\n"
+    "from botocore.exceptions import ClientError\n",
+    "s3 = boto3.client('s3')\n",
+    "sns = boto3.client('sns')\n",
+    "ssm = boto3.client('ssm')"
    ]
   },
   {
@@ -817,6 +820,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "if len(results['failed']) > 0:\n",
+    "    topicArn = ssm.get_parameter(Name=\"Orbit-Slack-Notifications\")[\"Parameter\"][\"Value\"]\n",
+    "    unmar_topicArn = json.loads(topicArn)\n",
+    "    try:\n",
+    "        response = sns.get_topic_attributes(\n",
+    "            TopicArn=unmar_topicArn['TopicArn']\n",
+    "        )\n",
+    "        d={}\n",
+    "        d['message']=results['failed']\n",
+    "        response = sns.publish(\n",
+    "            TopicArn=str(unmar_topicArn['TopicArn']),\n",
+    "            Message=json.dumps({'default': json.dumps(d)}),\n",
+    "            Subject='string',\n",
+    "            MessageStructure='json'\n",
+    "        )\n",
+    "    except ClientError as ex:\n",
+    "        if ex.response['Error']['Code'] == 'NotFoundException':\n",
+    "            print (\"SNS Topic doesnt exist\")\n",
+    "\n",
     "assert len(results['failed']) == 0"
    ]
   },


### PR DESCRIPTION
### Description:

This change will add ability to drop alerts to internal slack channel whenever a driver regression notebook fails.

Fixes #695 

### Issue Reference URL

https://github.com/awslabs/aws-eks-data-maker/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
