### PR TITLE
podsetting-pod-modifier not applying resources to pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - SSO property in the plugin manifest
 - Adding demo notebooks cron jobs cleaner job.
+
+### **Changed**
+
+- FIX: podsettings-pod-modifier wasn't applying resources to pods

--- a/images/orbit-controller/src/orbit_controller/pod.py
+++ b/images/orbit-controller/src/orbit_controller/pod.py
@@ -258,13 +258,13 @@ def apply_settings_to_pod(
         if "limits" in ps_spec["resources"]:
             pod_spec["resources"]["limits"] = {
                 **pod_spec["resources"].get("limits", {}),
-                **ps_spec["resources"].get("limits", {})
+                **ps_spec["resources"].get("limits", {}),
             }
 
         if "requests" in ps_spec["resources"]:
             pod_spec["resources"]["requests"] = {
                 **pod_spec["resources"].get("requests", {}),
-                **ps_spec["resources"].get("requests", {})
+                **ps_spec["resources"].get("requests", {}),
             }
 
     for container in filter_pod_containers(

--- a/images/orbit-controller/src/orbit_controller/pod.py
+++ b/images/orbit-controller/src/orbit_controller/pod.py
@@ -250,6 +250,23 @@ def apply_settings_to_pod(
         # Extend pod volumes with pod_setting volumes
         pod_spec["volumes"].extend(ps_spec.get("volumes", []))
 
+    # Merge
+    if "resources" in ps_spec:
+        if "resources" not in pod_spec:
+            pod_spec["resources"] = {}
+
+        if "limits" in ps_spec["resources"]:
+            pod_spec["resources"]["limits"] = {
+                **pod_spec["resources"].get("limits", {}),
+                **ps_spec["resources"].get("limits", {})
+            }
+
+        if "requests" in ps_spec["resources"]:
+            pod_spec["resources"]["requests"] = {
+                **pod_spec["resources"].get("requests", {}),
+                **ps_spec["resources"].get("requests", {})
+            }
+
     for container in filter_pod_containers(
         containers=pod_spec.get("initContainers", []),
         pod=pod_spec,


### PR DESCRIPTION
### Description:

- podsetting-pod-modifier not applying resources to pods

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
