### PR TITLE
reset resource_version when watch dies gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: Added default values to pull kubectl in the k8s-utilities image
 - FIX: Increase cluster-autoscaler resource limits
 - FIX: image-replicator fails if unable to prime env from image inventory
+- FIX: reset the resource_version in the orbit-controller when watch dies gracefully
 
 ### **Removed**
 

--- a/images/orbit-controller/src/orbit_controller/image_replication.py
+++ b/images/orbit-controller/src/orbit_controller/image_replication.py
@@ -273,8 +273,9 @@ def watch(
             logger.exception("Unknown error in ImageReplicationWatcher. Failing")
             raise
         else:
+            state["lastResourceVersion"] = "0"
             logger.warning(
-                "Watch died gracefully, starting back up with last_resource_version: %s",
+                "Watch died gracefully, starting back up with a reset resource_version: %s",
                 state["lastResourceVersion"],
             )
 

--- a/images/orbit-controller/src/orbit_controller/namespace.py
+++ b/images/orbit-controller/src/orbit_controller/namespace.py
@@ -273,8 +273,9 @@ def watch(queue: Queue, state: Dict[str, Any]) -> int:  # type: ignore
             logger.exception("Unknown error in UserspaceChartManager. Failing")
             raise
         else:
+            state["lastResourceVersion"] = "0"
             logger.warning(
-                "Watch died gracefully, starting back up with last_resource_version: %s",
+                "Watch died gracefully, starting back up with a reset resource_version: %s",
                 state["lastResourceVersion"],
             )
 

--- a/images/orbit-controller/src/orbit_controller/pod_default.py
+++ b/images/orbit-controller/src/orbit_controller/pod_default.py
@@ -199,8 +199,9 @@ def watch(queue: Queue, state: Dict[str, Any]) -> int:  # type: ignore
             logger.exception("Unknown error in PodDefaultWatcher. Failing")
             raise
         else:
+            state["lastResourceVersion"] = "0"
             logger.warning(
-                "Watch died gracefully, starting back up with last_resource_version: %s",
+                "Watch died gracefully, starting back up with a reset resource_version: %s",
                 state["lastResourceVersion"],
             )
 

--- a/images/orbit-controller/src/orbit_controller/pod_setting.py
+++ b/images/orbit-controller/src/orbit_controller/pod_setting.py
@@ -155,8 +155,9 @@ def watch(queue: Queue, state: Dict[str, Any]) -> int:  # type: ignore
             logger.exception("Unknown error in PodSettingWatcher. Failing")
             raise
         else:
+            state["lastResourceVersion"] = "0"
             logger.warning(
-                "Watch died gracefully, starting back up with last_resource_version: %s",
+                "Watch died gracefully, starting back up with a reset resource_version: %s",
                 state["lastResourceVersion"],
             )
 


### PR DESCRIPTION
### Description:

- reset resource_version when watch dies gracefully

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/840

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
