### PR TITLE
removing ray and overprovisioning plugins for now

### DIFF
--- a/samples/manifests/plugins/lake-admin-plugins.yaml
+++ b/samples/manifests/plugins/lake-admin-plugins.yaml
@@ -25,9 +25,3 @@
         image: public.ecr.aws/v3o4w1g6/aws-orbit-workbench/utility-data:latest
         uid: 0
         gid: 0
--   PluginId: overprovisioning1
-    Module: overprovisioning
-    Parameters:
-        replicas: 3
-        cpu: 2
-        memory: 4G

--- a/samples/manifests/plugins/lake-user-plugins.yaml
+++ b/samples/manifests/plugins/lake-user-plugins.yaml
@@ -40,7 +40,6 @@
         use_fips_ssl: "true"
         node_type: "DC2.large"
         number_of_nodes: "2"
-
 -   PluginId: enable_emr_on_eks
     Module: emr_on_eks
 -   PluginId: fast_fs_lustre
@@ -48,11 +47,6 @@
     Parameters:
         storage: 1200Gi
         folder: /fsx
--   PluginId: ray
-    Module: ray
-    Parameters:
-        workers: 3
-        release_tag: 1.3.0
 -   PluginId: sm-operator
     Module: sm-operator
 -   PluginId: team-voila


### PR DESCRIPTION
### Description:

Removed Ray and Overprovisioning plugins...

For Ref:
-   PluginId: ray
    Module: ray
    Parameters:
        workers: 3
        release_tag: 1.3.0

-   PluginId: overprovisioning1
    Module: overprovisioning
    Parameters:
        replicas: 3
        cpu: 2
        memory: 4G



### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/781

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
