### PR TITLE
fixed the issue which caused the ray workers not to join ray head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: Increase cluster-autoscaler resource limits
 - FIX: image-replicator fails if unable to prime env from image inventory
 - FIX: reset the resource_version in the orbit-controller when watch dies gracefully
+- FIX: fixed the issue of ray workers not joining ray head
+- FIX: reduced the sleep time for resources deletion between user spaces
+- FIX: Added `AuthenticationGroups` to the manifest.yaml under samples   
 
 ### **Removed**
 

--- a/plugins/ray/ray/values.yaml
+++ b/plugins/ray/ray/values.yaml
@@ -31,6 +31,7 @@ env:
 podAnnotations: {}
 restartPolicy: ${restart_policy}
 headLabels:
+  orbit/attach-security-group: "yes"
   orbit/node-type: ec2
   app: "orbit-ray"
   component: ray-head

--- a/samples/manifests/demo/manifest.yaml
+++ b/samples/manifests/demo/manifest.yaml
@@ -44,6 +44,8 @@ Teams:
     - 0.0.0.0/0
     Plugins: !include lake-admin-plugins.yaml
     EfsLifeCycle: AFTER_7_DAYS
+    AuthenticationGroups:
+    - lake-admin
 -   Name: lake-creator
     Policies:
     - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-creator-add-policy
@@ -54,6 +56,8 @@ Teams:
     - 0.0.0.0/0
     Plugins: !include lake-creator-plugins.yaml
     EfsLifeCycle: AFTER_7_DAYS
+    AuthenticationGroups:
+    - lake-creator
 -   Name: lake-user
     Policies:
     - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-user-add-policy
@@ -63,3 +67,5 @@ Teams:
     Profiles: !include lake-user-profiles.json
     Plugins: !include lake-user-plugins.yaml
     EfsLifeCycle: AFTER_7_DAYS
+    AuthenticationGroups:
+    - lake-user


### PR DESCRIPTION
### Description:

Team specific security group was missing on the ray head, further causing timeout issues for the traffic coming into the `branch-eni` of ray head from worker pods.

### Issue Reference URL

#677 

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
