### PR TITLE
Feature/multi region orbit

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -72,7 +72,7 @@
 
 * Install [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html)
 * Go to the IAM console
-* Find the Admin Role (`arn:aws:iam::{ACCOUNT_ID}:role/orbit-{ENV_NAME}-admin`).
+* Find the Admin Role (`arn:aws:iam::{ACCOUNT_ID}:role/orbit-{ENV_NAME}-{REGION}-admin`).
 * Add your user or role under the `Trust Relationship` tab.
 
 ```json
@@ -86,7 +86,7 @@
 ```
 
 * Open the temrinal and user the AWS CLI to configure your kubeconfig
-* `aws eks update-kubeconfig --name orbit-{ENV_NAME} --role-arn arn:aws:iam::{ACCOUNT_ID}:role/orbit-{ENV_NAME}-admin`
+* `aws eks update-kubeconfig --name orbit-{ENV_NAME} --role-arn arn:aws:iam::{ACCOUNT_ID}:role/orbit-{ENV_NAME}-{REGION}-admin`
 * Validate you access
 * `kubectl get pod -A`
 

--- a/cli/aws_orbit/cleanup.py
+++ b/cli/aws_orbit/cleanup.py
@@ -163,7 +163,7 @@ def foundation_remaining_dependencies_contextless(env_name: str, vpc_id: Optiona
 
 def delete_cert_from_iam(context: "FoundationContext") -> None:
     iam_client = boto3_client("iam")
-    cert_name = context.name
+    cert_name = f"{context.name}-{context.region}"
     try:
         iam_client.delete_server_certificate(ServerCertificateName=cert_name)
     except botocore.exceptions.ClientError as ex:

--- a/cli/aws_orbit/commands/deploy.py
+++ b/cli/aws_orbit/commands/deploy.py
@@ -178,7 +178,7 @@ def deploy_foundation(
                 name=name,
                 codeartifact_domain=codeartifact_domain,
                 codeartifact_repository=codeartifact_repository,
-                ssm_parameter_name=f"/orbit-foundation/{name}/manifest",
+                ssm_parameter_name=f"/orbit-f/{name}/manifest",
                 networking=NetworkingManifest(data=DataNetworkingManifest(internet_accessible=internet_accessibility)),
             )
         else:
@@ -195,7 +195,7 @@ def deploy_foundation(
 
         _deploy_toolkit(
             context=cast(Context, context),
-            top_level="orbit-foundation",
+            top_level="orbit-f",
         )
         msg_ctx.info("Toolkit deployed")
         msg_ctx.progress(8)

--- a/cli/aws_orbit/commands/destroy.py
+++ b/cli/aws_orbit/commands/destroy.py
@@ -147,12 +147,12 @@ def destroy_env(env: str, debug: bool) -> None:
 
 def destroy_foundation(env: str, debug: bool) -> None:
     with MessagesContext("Destroying", debug=debug) as msg_ctx:
-        ssm.cleanup_changeset(env_name=env, top_level="orbit-foundation")
-        ssm.cleanup_manifest(env_name=env, top_level="orbit-foundation")
+        ssm.cleanup_changeset(env_name=env, top_level="orbit-f")
+        ssm.cleanup_manifest(env_name=env, top_level="orbit-f")
 
-        if ssm.does_parameter_exist(name=f"/orbit-foundation/{env}/context") is False:
+        if ssm.does_parameter_exist(name=f"/orbit-f/{env}/context") is False:
             msg_ctx.info(f"Foundation {env} not found. Destroying only possible remaining resources.")
-            destroy_remaining_resources(env_name=env, top_level="orbit-foundation")
+            destroy_remaining_resources(env_name=env, top_level="orbit-f")
             msg_ctx.progress(100)
             return
 
@@ -188,14 +188,14 @@ def destroy_foundation(env: str, debug: bool) -> None:
         msg_ctx.progress(95)
 
         try:
-            destroy_toolkit(env_name=context.name, top_level="orbit-foundation")
+            destroy_toolkit(env_name=context.name, top_level="orbit-f")
         except botocore.exceptions.ClientError as ex:
             error = ex.response["Error"]
             if "does not exist" not in error["Message"]:
                 raise
             _logger.debug(f"Skipping toolkit destroy: {error['Message']}")
         msg_ctx.info("Toolkit destroyed")
-        ssm.cleanup_env(env_name=context.name, top_level="orbit-foundation")
+        ssm.cleanup_env(env_name=context.name, top_level="orbit-f")
 
         msg_ctx.progress(100)
 

--- a/cli/aws_orbit/data/kubectl/kube-system/02-cluster-autoscaler-autodiscover.yaml
+++ b/cli/aws_orbit/data/kubectl/kube-system/02-cluster-autoscaler-autodiscover.yaml
@@ -8,7 +8,7 @@ metadata:
   name: cluster-autoscaler
   namespace: kube-system
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::${account_id}:role/orbit-${env_name}-cluster-autoscaler-role
+    eks.amazonaws.com/role-arn: arn:aws:iam::${account_id}:role/orbit-${env_name}-${region}-cluster-autoscaler-role
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cli/aws_orbit/data/kubectl/orbit-system/00-commons.yaml
+++ b/cli/aws_orbit/data/kubectl/orbit-system/00-commons.yaml
@@ -14,7 +14,7 @@ metadata:
   name: orbit-${env_name}-admin
   namespace: orbit-system
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::${account_id}:role/orbit-${env_name}-admin
+    eks.amazonaws.com/role-arn: arn:aws:iam::${account_id}:role/orbit-${env_name}-${region}-admin
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/aws_orbit/data/toolkit/template.yaml
+++ b/cli/aws_orbit/data/toolkit/template.yaml
@@ -248,7 +248,7 @@ Resources:
               - arn:aws:serverlessrepo:us-east-1:903779448426:applications/lambda-layer-kubectl
         Version: '2012-10-17'
       Description: ''
-      ManagedPolicyName: ${top_level}-${env_name}-admin-other
+      ManagedPolicyName: ${top_level}-${env_name}-${region}-admin-other
       Path: /
   OrbitAdminPolicyIAMS3:
     Type: AWS::IAM::ManagedPolicy
@@ -277,10 +277,10 @@ Resources:
               - arn:aws:s3:::${top_level}-${env_name}-toolkit-${account_id}-${deploy_id}
               - arn:aws:s3:::${top_level}-${env_name}-cdk-toolkit-${account_id}-${deploy_id}/*
               - arn:aws:s3:::${top_level}-${env_name}-cdk-toolkit-${account_id}-${deploy_id}
-              - arn:aws:s3:::${top_level}-${env_name}-demo-lake-${account_id}-${deploy_id}/*
-              - arn:aws:s3:::${top_level}-${env_name}-demo-lake-${account_id}-${deploy_id}
-              - arn:aws:s3:::${top_level}-${env_name}-secured-demo-lake-${account_id}-${deploy_id}/*
-              - arn:aws:s3:::${top_level}-${env_name}-secured-demo-lake-${account_id}-${deploy_id}
+              - arn:aws:s3:::${top_level}-${env_name}-${region}-demo-lake-${account_id}-${deploy_id}/*
+              - arn:aws:s3:::${top_level}-${env_name}-${region}-demo-lake-${account_id}-${deploy_id}
+              - arn:aws:s3:::${top_level}-${env_name}-${region}-secured-demo-lake-${account_id}-${deploy_id}/*
+              - arn:aws:s3:::${top_level}-${env_name}-${region}-secured-demo-lake-${account_id}-${deploy_id}
           - Effect: Allow
             Action:
               - s3:GetEncryptionConfiguration
@@ -334,10 +334,10 @@ Resources:
             Action:
               - sts:AssumeRole
             Resource:
-              - arn:aws:iam::${account_id}:role/${top_level}-${env_name}-admin
+              - arn:aws:iam::${account_id}:role/${top_level}-${env_name}-${region}-admin
         Version: '2012-10-17'
       Description: ''
-      ManagedPolicyName: ${top_level}-${env_name}-admin-iam-s3
+      ManagedPolicyName: ${top_level}-${env_name}-${region}-admin-iam-s3
       Path: /
   AdminRole:
     Type: AWS::IAM::Role
@@ -347,7 +347,7 @@ Resources:
         - Ref: OrbitAdminPolicyOther
         - Ref: OrbitAdminPolicyIAMS3
         - Ref: OrbitCodeArtifactPolicy
-      RoleName: ${top_level}-${env_name}-admin
+      RoleName: ${top_level}-${env_name}-${region}-admin
       MaxSessionDuration: 10000
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -456,6 +456,10 @@ Outputs:
     Value: '${deploy_id}'
     Export:
       Name: ${top_level}-${env_name}-deploy-id
+  AdminRole:
+    Value: !Ref AdminRole
+    Export:
+      Name: ${top_level}-${env_name}-admin-role
   KmsKeyArn:
     Value:
       Fn::GetAtt:

--- a/cli/aws_orbit/models/context.py
+++ b/cli/aws_orbit/models/context.py
@@ -189,6 +189,7 @@ class ToolkitManifest:
     stack_name: str
     codebuild_project: str
     deploy_id: Optional[str] = None
+    admin_role: Optional[str] = None
     kms_arn: Optional[str] = None
     kms_alias: Optional[str] = None
     s3_bucket: Optional[str] = None
@@ -447,7 +448,7 @@ class ContextSerDe(Generic[T, V]):
     @staticmethod
     def _load_foundation_context_from_manifest(manifest: "FoundationManifest") -> FoundationContext:
         _logger.debug("Loading Context from manifest")
-        context_parameter_name: str = f"/orbit-foundation/{manifest.name}/context"
+        context_parameter_name: str = f"/orbit-f/{manifest.name}/context"
         if ssm.does_parameter_exist(name=context_parameter_name):
             context: FoundationContext = ContextSerDe.load_context_from_ssm(
                 env_name=manifest.name, type=FoundationContext
@@ -461,20 +462,20 @@ class ContextSerDe(Generic[T, V]):
                 name=manifest.name,
                 account_id=utils.get_account_id(),
                 region=utils.get_region(),
-                env_tag=f"orbit-foundation-{manifest.name}",
+                env_tag=f"orbit-f-{manifest.name}",
                 ssm_parameter_name=context_parameter_name,
-                resources_ssm_parameter_name=f"/orbit-foundation/{manifest.name}/resources",
+                resources_ssm_parameter_name=f"/orbit-f/{manifest.name}/resources",
                 toolkit=ToolkitManifest(
-                    stack_name=f"orbit-foundation-{manifest.name}-toolkit",
-                    codebuild_project=f"orbit-foundation-{manifest.name}",
+                    stack_name=f"orbit-f-{manifest.name}-toolkit",
+                    codebuild_project=f"orbit-f-{manifest.name}",
                 ),
-                cdk_toolkit=CdkToolkitManifest(stack_name=f"orbit-foundation-{manifest.name}-cdk-toolkit"),
+                cdk_toolkit=CdkToolkitManifest(stack_name=f"orbit-f-{manifest.name}-cdk-toolkit"),
                 codeartifact_domain=manifest.codeartifact_domain,
                 codeartifact_repository=manifest.codeartifact_repository,
                 networking=create_networking_context_from_manifest(networking=manifest.networking),
                 images=manifest.images,
                 policies=manifest.policies,
-                stack_name=f"orbit-foundation-{manifest.name}",
+                stack_name=f"orbit-f-{manifest.name}",
             )
         ContextSerDe.fetch_toolkit_data(context=context)
         ContextSerDe.dump_context_to_ssm(context=context)
@@ -534,7 +535,7 @@ class ContextSerDe(Generic[T, V]):
             main["Teams"] = [t for t in teams if t]
             return cast(V, Context.Schema().load(data=main, many=False, partial=False, unknown="EXCLUDE"))
         elif type is FoundationContext:
-            context_parameter_name = f"/orbit-foundation/{env_name}/context"
+            context_parameter_name = f"/orbit-f/{env_name}/context"
             main = ssm.get_parameter(name=context_parameter_name)
             return cast(V, FoundationContext.Schema().load(data=main, many=False, partial=False, unknown="EXCLUDE"))
         else:
@@ -546,7 +547,7 @@ class ContextSerDe(Generic[T, V]):
         if not (isinstance(context, Context) or isinstance(context, FoundationContext)):
             raise ValueError("Unknown 'context' Type")
 
-        top_level = "orbit" if isinstance(context, Context) else "orbit-foundation"
+        top_level = "orbit" if isinstance(context, Context) else "orbit-f"
 
         resp_type = Dict[str, List[Dict[str, List[Dict[str, str]]]]]
         try:
@@ -578,6 +579,10 @@ class ContextSerDe(Generic[T, V]):
             if output["ExportName"] == f"{top_level}-{context.name}-kms-arn":
                 _logger.debug("Export value: %s", output["OutputValue"])
                 context.toolkit.kms_arn = output["OutputValue"]
+            if output["ExportName"] == f"{top_level}-{context.name}-admin-role":
+                _logger.debug("Export value: %s", output["OutputValue"])
+                context.toolkit.admin_role = output["OutputValue"]
+
         if context.toolkit.deploy_id is None:
             raise RuntimeError(
                 f"Stack {context.toolkit.stack_name} does not have the expected {top_level}-{context.name}-deploy-id output."
@@ -586,6 +591,11 @@ class ContextSerDe(Generic[T, V]):
             raise RuntimeError(
                 f"Stack {context.toolkit.stack_name} does not have the expected {top_level}-{context.name}-kms-arn output."
             )
+        if context.toolkit.admin_role is None:
+            raise RuntimeError(
+                f"Stack {context.toolkit.stack_name} does not have the expected {top_level}-{context.name}-admin-role output."
+            )
+
         context.toolkit.kms_alias = f"{top_level}-{context.name}-{context.toolkit.deploy_id}"
         context.toolkit.s3_bucket = (
             f"{top_level}-{context.name}-toolkit-{context.account_id}-{context.toolkit.deploy_id}"

--- a/cli/aws_orbit/models/manifest.py
+++ b/cli/aws_orbit/models/manifest.py
@@ -233,11 +233,11 @@ def _add_ssm_param_injector(tag: str = "!SSM") -> Set[str]:
     to be parsed: ${SSM_PARAMETER_PATH::JSONPATH}.
     E.g.:
     database:
-        host: !SSM ${/orbit-foundation/dev-env/resources::/UserAccessPolicy}
-        port: !SSM ${/orbit-foundation/dev-env/resources::/PublicSubnet/*}
+        host: !SSM ${/orbit-f/dev-env/resources::/UserAccessPolicy}
+        port: !SSM ${/orbit-f/dev-env/resources::/PublicSubnet/*}
     """
     # pattern for global vars: look for ${word}
-    pattern = re.compile(".*?\${(.*)}.*?")  # noqa: W605
+    pattern = re.compile(".*?\${(.[0-9a-zA-Z-_:/]+)}.*?")  # noqa: W605
     loader = yaml.SafeLoader
 
     # the tag will be used to mark where to start searching for the pattern
@@ -307,7 +307,7 @@ def _add_env_var_injector(tag: str = "!ENV") -> None:
         something_else: !ENV '${AWESOME_ENV_VAR}/var/${A_SECOND_AWESOME_VAR}'
     """
     # pattern for global vars: look for ${word}
-    pattern = re.compile(".*?\${(.*)}.*?")  # noqa: W605
+    pattern = re.compile(".*?\${(.[0-9a-zA-Z-_:]+)}.*?")  # noqa: W605
     loader = yaml.SafeLoader
 
     # the tag will be used to mark where to start searching for the pattern
@@ -360,7 +360,7 @@ class ManifestSerDe(Generic[T]):
             raw["SsmParameterName"] = f"/orbit/{raw['Name']}/manifest"
             manifest: T = cast(T, Manifest.Schema().load(data=raw, many=False, partial=False, unknown=EXCLUDE))
         elif type is FoundationManifest:
-            raw["SsmParameterName"] = f"/orbit-foundation/{raw['Name']}/manifest"
+            raw["SsmParameterName"] = f"/orbit-f/{raw['Name']}/manifest"
             manifest = cast(T, FoundationManifest.Schema().load(data=raw, many=False, partial=False, unknown=EXCLUDE))
         else:
             raise ValueError("Unknown 'manifest' Type")
@@ -396,7 +396,7 @@ class ManifestSerDe(Generic[T]):
             manifest_parameter_name = manifest.ssm_parameter_name
         elif isinstance(manifest, FoundationManifest):
             content = cast(Dict[str, Any], FoundationManifest.Schema().dump(manifest))
-            ssm.cleanup_manifest(env_name=manifest.name, top_level="orbit-foundation")
+            ssm.cleanup_manifest(env_name=manifest.name, top_level="orbit-f")
             manifest_parameter_name = manifest.ssm_parameter_name
         else:
             raise ValueError("Unknown 'manifest' Type")
@@ -416,7 +416,7 @@ class ManifestSerDe(Generic[T]):
             main["Teams"] = teams
             return cast(T, Manifest.Schema().load(data=main, many=False, partial=False, unknown=EXCLUDE))
         elif type is FoundationManifest:
-            context_parameter_name = f"/orbit-foundation/{env_name}/manifest"
+            context_parameter_name = f"/orbit-f/{env_name}/manifest"
             main = ssm.get_parameter_if_exists(name=context_parameter_name)
             if main is None:
                 return None

--- a/cli/aws_orbit/remote_files/cdk/env.py
+++ b/cli/aws_orbit/remote_files/cdk/env.py
@@ -90,7 +90,7 @@ class Env(Stack):
         self._create_post_authentication_lambda()
 
     def _create_role_cluster(self) -> iam.Role:
-        name: str = f"orbit-{self.context.name}-eks-cluster-role"
+        name: str = f"orbit-{self.context.name}-{self.context.region}-eks-cluster-role"
         role = iam.Role(
             scope=self,
             id=name,
@@ -148,7 +148,7 @@ class Env(Stack):
         return role
 
     def _create_role_fargate_profile(self) -> iam.Role:
-        name: str = f"orbit-{self.context.name}-eks-fargate-profile-role"
+        name: str = f"orbit-{self.context.name}-{self.context.region}-eks-fargate-profile-role"
         return iam.Role(
             scope=self,
             id=name,
@@ -187,7 +187,7 @@ class Env(Stack):
         )
 
     def _create_env_nodegroup_role(self) -> iam.Role:
-        name: str = f"orbit-{self.context.name}-eks-nodegroup-role"
+        name: str = f"orbit-{self.context.name}-{self.context.region}-eks-nodegroup-role"
         role = iam.Role(
             scope=self,
             id=name,
@@ -205,7 +205,7 @@ class Env(Stack):
         return role
 
     def _create_cluster_autoscaler_role(self) -> iam.Role:
-        name: str = f"orbit-{self.context.name}-cluster-autoscaler-role"
+        name: str = f"orbit-{self.context.name}-{self.context.region}-cluster-autoscaler-role"
         return iam.Role(
             scope=self,
             id=name,
@@ -269,7 +269,7 @@ class Env(Stack):
                 )
             ],
         )
-        name = f"{self.id}-cognito-authenticated-identity-role"
+        name = f"{self.id}-{self.context.region}-cognito-authenticated-identity-role"
         authenticated_role = iam.Role(
             scope=self,
             id=name,
@@ -311,7 +311,7 @@ class Env(Stack):
                 ),
             },
         )
-        name = f"{self.id}-cognito-unauthenticated-identity-role"
+        name = f"{self.id}-{self.context.region}-cognito-unauthenticated-identity-role"
         unauthenticated_role = iam.Role(
             scope=self,
             id=name,
@@ -416,7 +416,7 @@ class Env(Stack):
             parameters={"LayerName": k8s_layer_name},
         )
 
-        role_name = f"orbit-{self.context.name}-admin"
+        role_name = self.context.toolkit.admin_role
         role_arn = f"arn:aws:iam::{self.context.account_id}:role/{role_name}"
 
         lambda_python.PythonFunction(

--- a/cli/aws_orbit/remote_files/cdk/foundation.py
+++ b/cli/aws_orbit/remote_files/cdk/foundation.py
@@ -83,7 +83,7 @@ class FoundationStack(Stack):
         toolkit_s3_bucket_name: str = context.toolkit.s3_bucket
         acct: str = core.Aws.ACCOUNT_ID
         self.bucket_names: Dict[str, Any] = {
-            "scratch-bucket": f"orbit-foundation-{self.env_name}-scratch-{acct}-{context.toolkit.deploy_id}",
+            "scratch-bucket": f"orbit-f-{self.env_name}-scratch-{acct}-{context.toolkit.deploy_id}",
             "toolkit-bucket": toolkit_s3_bucket_name,
         }
         self._build_kms_key_for_env()
@@ -154,33 +154,33 @@ class FoundationStack(Stack):
         CfnOutput(
             scope=self,
             id=f"{id}vpcid",
-            export_name=f"orbit-foundation-{self.env_name}-vpc-id",
+            export_name=f"orbit-f-{self.env_name}-vpc-id",
             value=self.vpc.vpc_id,
         )
 
         CfnOutput(
             scope=self,
             id=f"{id}publicsubnetsids",
-            export_name=f"orbit-foundation-{self.env_name}-public-subnet-ids",
+            export_name=f"orbit-f-{self.env_name}-public-subnet-ids",
             value=",".join(self.public_subnets.subnet_ids),
         )
         CfnOutput(
             scope=self,
             id=f"{id}privatesubnetsids",
-            export_name=f"orbit-foundation-{self.env_name}-private-subnet-ids",
+            export_name=f"orbit-f-{self.env_name}-private-subnet-ids",
             value=",".join(self.private_subnets.subnet_ids),
         )
         if not context.networking.data.internet_accessible:
             CfnOutput(
                 scope=self,
                 id=f"{id}isolatedsubnetsids",
-                export_name=f"orbit-foundation-{self.env_name}-isolated-subnet-ids",
+                export_name=f"orbit-f-{self.env_name}-isolated-subnet-ids",
                 value=",".join(self.isolated_subnets.subnet_ids),
             )
         CfnOutput(
             scope=self,
             id=f"{id}nodesubnetsids",
-            export_name=f"orbit-foundation-{self.env_name}-nodes-subnet-ids",
+            export_name=f"orbit-f-{self.env_name}-nodes-subnet-ids",
             value=",".join(self.nodes_subnets.subnet_ids),
         )
 

--- a/cli/aws_orbit/remote_files/cdk/lambda_sources/cognito_post_authentication/k8s_manage.py
+++ b/cli/aws_orbit/remote_files/cdk/lambda_sources/cognito_post_authentication/k8s_manage.py
@@ -14,6 +14,8 @@ logger.setLevel(logging.INFO)
 
 ORBIT_ENV = os.environ.get("ORBIT_ENV")
 ACCOUNT_ID = os.environ.get("ACCOUNT_ID")
+REGION = os.environ.get("REGION")
+
 KUBECONFIG_PATH = "/tmp/.kubeconfig"
 
 ssm = boto3.client("ssm")
@@ -47,7 +49,7 @@ def create_kubeconfig() -> None:
         (
             "aws eks update-kubeconfig "
             f"--name orbit-{ORBIT_ENV} "
-            f"--role-arn arn:aws:iam::{ACCOUNT_ID}:role/orbit-{ORBIT_ENV}-admin "
+            f"--role-arn arn:aws:iam::{ACCOUNT_ID}:role/orbit-{ORBIT_ENV}-{REGION}-admin "
             f"--kubeconfig {KUBECONFIG_PATH}"
         )
     )

--- a/cli/aws_orbit/remote_files/cdk/team_builders/iam.py
+++ b/cli/aws_orbit/remote_files/cdk/team_builders/iam.py
@@ -44,8 +44,7 @@ class IamBuilder:
         partition = core.Aws.PARTITION
         account = core.Aws.ACCOUNT_ID
         region = core.Aws.REGION
-
-        lake_role_name: str = f"orbit-{env_name}-{team_name}-role"
+        lake_role_name: str = f"orbit-{env_name}-{team_name}-{region}-role"
         kms_keys = [team_kms_key.key_arn]
         scratch_bucket_kms_key = IamBuilder.get_kms_key_scratch_bucket(context=context)
         if scratch_bucket_kms_key:
@@ -54,7 +53,7 @@ class IamBuilder:
         lake_operational_policy = iam.ManagedPolicy(
             scope=scope,
             id="lake_operational_policy",
-            managed_policy_name=f"orbit-{env_name}-{team_name}-user-access",
+            managed_policy_name=f"orbit-{env_name}-{team_name}-{region}-user-access",
             statements=[
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
@@ -338,7 +337,7 @@ class IamBuilder:
 
         role = iam.Role(
             scope=scope,
-            id=lake_role_name,
+            id=f"lakerole-for-{env_name}-{team_name}",
             role_name=lake_role_name,
             assumed_by=cast(
                 iam.IPrincipal,

--- a/cli/aws_orbit/remote_files/cert.py
+++ b/cli/aws_orbit/remote_files/cert.py
@@ -52,7 +52,7 @@ def deploy_selfsigned_cert(context: "FoundationContext") -> str:
 def upload_cert_iam(context: "FoundationContext", private_pem: str, public_pem: str) -> str:
     """ Uploads the cert to AWS IAM """
     iam_client = boto3.client("iam")
-    ssl_cert_name = context.name
+    ssl_cert_name = f"{context.name}-{context.region}"
     try:
         response = iam_client.get_server_certificate(ServerCertificateName=ssl_cert_name)
         return cast(str, response["ServerCertificate"]["ServerCertificateMetadata"]["Arn"])

--- a/cli/aws_orbit/remote_files/eksctl.py
+++ b/cli/aws_orbit/remote_files/eksctl.py
@@ -328,7 +328,7 @@ def deploy_env(context: "Context", changeset: Optional[Changeset]) -> None:
             "--write-kubeconfig --verbose 4"
         )
 
-        username = f"orbit-{context.name}-admin"
+        username = context.toolkit.admin_role
         arn = f"arn:aws:iam::{context.account_id}:role/{username}"
         _logger.debug(f"Adding IAM Identity Mapping - Role: {arn}, Username: {username}, Group: system:masters")
         sh.run(
@@ -410,7 +410,7 @@ def deploy_env(context: "Context", changeset: Optional[Changeset]) -> None:
     authorize_cluster_pod_security_group(context=context)
 
     iam.add_assume_role_statement(
-        role_name=f"orbit-{context.name}-cluster-autoscaler-role",
+        role_name=f"orbit-{context.name}-{context.region}-cluster-autoscaler-role",
         statement={
             "Effect": "Allow",
             "Principal": {"Federated": f"arn:aws:iam::{context.account_id}:oidc-provider/{context.eks_oidc_provider}"},
@@ -424,7 +424,7 @@ def deploy_env(context: "Context", changeset: Optional[Changeset]) -> None:
     )
 
     iam.add_assume_role_statement(
-        role_name=f"orbit-{context.name}-eks-cluster-role",
+        role_name=f"orbit-{context.name}-{context.region}-eks-cluster-role",
         statement={
             "Effect": "Allow",
             "Principal": {"Federated": f"arn:aws:iam::{context.account_id}:oidc-provider/{context.eks_oidc_provider}"},
@@ -438,7 +438,7 @@ def deploy_env(context: "Context", changeset: Optional[Changeset]) -> None:
     )
 
     iam.add_assume_role_statement(
-        role_name=f"orbit-{context.name}-admin",
+        role_name=cast(str, context.toolkit.admin_role),
         statement={
             "Effect": "Allow",
             "Principal": {"Federated": f"arn:aws:iam::{context.account_id}:oidc-provider/{context.eks_oidc_provider}"},

--- a/cli/aws_orbit/remote_files/env.py
+++ b/cli/aws_orbit/remote_files/env.py
@@ -14,7 +14,7 @@
 
 import logging
 import os
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, cast
 
 import boto3
 
@@ -62,7 +62,7 @@ def deploy(
     ):
         iam.update_assume_role_roles(
             account_id=context.account_id,
-            role_name=f"orbit-{context.name}-admin",
+            role_name=cast(str, context.toolkit.admin_role),
             roles_to_add=eks_system_masters_roles_changes.added_values,
             roles_to_remove=eks_system_masters_roles_changes.removed_values,
         )

--- a/samples/manifests/demo/demo-lake-admin-cfn-template.yaml
+++ b/samples/manifests/demo/demo-lake-admin-cfn-template.yaml
@@ -65,6 +65,8 @@ Resources:
         - ''
         - - 'orbit-'
           - !Ref envname
+          - '-'
+          - !Ref "AWS::Region"
           - '-demo-lake-admin-add-policy'
       Path: /
 

--- a/samples/manifests/demo/demo-lake-creator-cfn-template.yaml
+++ b/samples/manifests/demo/demo-lake-creator-cfn-template.yaml
@@ -29,6 +29,8 @@ Resources:
         - ''
         - - 'orbit-'
           - !Ref envname
+          - '-'
+          - !Ref "AWS::Region"
           - '-demo-lake-'
           - !Ref 'AWS::AccountId'
           - '-'
@@ -62,6 +64,8 @@ Resources:
         - ''
         - - 'orbit-'
           - !Ref envname
+          - '-'
+          - !Ref "AWS::Region"
           - '-secured-demo-lake-'
           - !Ref 'AWS::AccountId'
           - '-'
@@ -166,6 +170,8 @@ Resources:
         - ''
         - - 'orbit-'
           - !Ref envname
+          - '-'
+          - !Ref "AWS::Region"
           - '-demo-lake-creator-add-policy'
       Path: /
 

--- a/samples/manifests/demo/demo-lake-user-cfn-template.yaml
+++ b/samples/manifests/demo/demo-lake-user-cfn-template.yaml
@@ -112,6 +112,8 @@ Resources:
         - ''
         - - 'orbit-'
           - !Ref envname
+          - '-'
+          - !Ref "AWS::Region"
           - '-demo-lake-user-add-policy'
       Path: /
   LakeUserGroup:

--- a/samples/manifests/demo/lake-creator-plugins.yaml
+++ b/samples/manifests/demo/lake-creator-plugins.yaml
@@ -75,5 +75,5 @@
         use_fips_ssl: "true"
         node_type: "DC2.large"
         number_of_nodes: "2"
--   PluginId: fast_fs_lustre
-    Module: lustre
+# -   PluginId: fast_fs_lustre
+#     Module: lustre

--- a/samples/manifests/demo/lake-user-plugins.yaml
+++ b/samples/manifests/demo/lake-user-plugins.yaml
@@ -43,8 +43,8 @@
 -   PluginId: enable_emr_on_eks
     Module: emr_on_eks
 # provide ability for containers to create fast fs for data science loads
--   PluginId: fast_fs_lustre
-    Module: lustre
+# -   PluginId: fast_fs_lustre
+#     Module: lustre
 -   PluginId: ray
     Module: ray
     Parameters:

--- a/samples/manifests/demo/manifest.yaml
+++ b/samples/manifests/demo/manifest.yaml
@@ -2,22 +2,22 @@ Name: !ENV ${ORBIT_ENV_NAME::dev-env}
 EksSystemMastersRoles:
 - !ENV ${ORBIT_ADMIN_ROLE::Admin}
 - !ENV ${ORBIT_ADMIN_DEMO_ROLE::Admin}
-ScratchBucketArn: !SSM ${/orbit-foundation/demo-fndn/resources::ScratchBucketArn}
-UserPoolId: !SSM ${/orbit-foundation/demo-fndn/resources::UserPoolId}
-SharedEfsFsId: !SSM ${/orbit-foundation/demo-fndn/resources::SharedEfsFsId}
-SharedEfsSgId: !SSM ${/orbit-foundation/demo-fndn/resources::SharedEfsSgId}
+ScratchBucketArn: !SSM ${/orbit-f/dev-env/resources::ScratchBucketArn}
+UserPoolId: !SSM ${/orbit-f/dev-env/resources::UserPoolId}
+SharedEfsFsId: !SSM ${/orbit-f/dev-env/resources::SharedEfsFsId}
+SharedEfsSgId: !SSM ${/orbit-f/dev-env/resources::SharedEfsSgId}
 InstallSsmAgent: true
 Networking:
-    VpcId: !SSM ${/orbit-foundation/demo-fndn/resources::VpcId}
-    PublicSubnets: !SSM ${/orbit-foundation/demo-fndn/resources::PublicSubnets}
-    PrivateSubnets: !SSM ${/orbit-foundation/demo-fndn/resources::PrivateSubnets}
-    IsolatedSubnets: !SSM ${/orbit-foundation/demo-fndn/resources::IsolatedSubnets}
+    VpcId: !SSM ${/orbit-f/dev-env/resources::VpcId}
+    PublicSubnets: !SSM ${/orbit-f/dev-env/resources::PublicSubnets}
+    PrivateSubnets: !SSM ${/orbit-f/dev-env/resources::PrivateSubnets}
+    IsolatedSubnets: !SSM ${/orbit-f/dev-env/resources::IsolatedSubnets}
     Data:
         InternetAccessible: true
-        NodesSubnets: !SSM ${/orbit-foundation/demo-fndn/resources::NodesSubnets}
+        NodesSubnets: !SSM ${/orbit-f/dev-env/resources::NodesSubnets}
     Frontend:
-        LoadBalancersSubnets: !SSM ${/orbit-foundation/demo-fndn/resources::LoadBalancersSubnets}
-        SslCertArn: !SSM ${/orbit-foundation/demo-fndn/resources::SslCertArn}
+        LoadBalancersSubnets: !SSM ${/orbit-f/dev-env/resources::LoadBalancersSubnets}
+        SslCertArn: !SSM ${/orbit-f/dev-env/resources::SslCertArn}
 ManagedNodegroups:
 -   Name: primary-compute
     InstanceType: m5.2xlarge
@@ -36,7 +36,7 @@ ManagedNodegroups:
 Teams:
 -   Name: lake-admin
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-admin-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-admin-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: true
@@ -48,7 +48,7 @@ Teams:
     - lake-admin
 -   Name: lake-creator
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-creator-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-creator-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: false
@@ -60,7 +60,7 @@ Teams:
     - lake-creator
 -   Name: lake-user
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-user-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-user-add-policy
     JupyterhubInboundRanges:
     - 0.0.0.0/0
     GrantSudo: true

--- a/samples/manifests/minimal/dev-env.yaml
+++ b/samples/manifests/minimal/dev-env.yaml
@@ -3,10 +3,10 @@ CodeartifactDomain: !ENV ${CODEARTIFACT_DOMAIN::}
 CodeartifactRepository: !ENV ${CODEARTIFACT_REPOSITORY::}
 EksSystemMastersRoles:
 -   !ENV ${ORBIT_ADMIN_ROLE::Admin}
-ScratchBucketArn: !SSM ${/orbit-foundation/dev-env/resources::ScratchBucketArn}
-UserPoolId: !SSM ${/orbit-foundation/dev-env/resources::UserPoolId}
-SharedEfsFsId: !SSM ${/orbit-foundation/dev-env/resources::SharedEfsFsId}
-SharedEfsSgId: !SSM ${/orbit-foundation/dev-env/resources::SharedEfsSgId}
+ScratchBucketArn: !SSM ${/orbit-f/dev-env/resources::ScratchBucketArn}
+UserPoolId: !SSM ${/orbit-f/dev-env/resources::UserPoolId}
+SharedEfsFsId: !SSM ${/orbit-f/dev-env/resources::SharedEfsFsId}
+SharedEfsSgId: !SSM ${/orbit-f/dev-env/resources::SharedEfsSgId}
 InstallSsmAgent: true
 CognitoExternalProvider: !ENV ${COGNITO_EXTERNAL_PROVIDER::}
 CognitoExternalProviderLabel: !ENV ${COGNITO_EXTERNAL_PROVIDER_LABEL::}
@@ -21,16 +21,16 @@ Images:
         Repository: !ENV ${UTILITY_DATA_REPO::public.ecr.aws/v3o4w1g6/aws-orbit-workbench/utility-data}
         Version: !ENV ${VERSION::latest}
 Networking:
-    VpcId: !SSM ${/orbit-foundation/dev-env/resources::VpcId}
-    PublicSubnets: !SSM ${/orbit-foundation/dev-env/resources::PublicSubnets}
-    PrivateSubnets: !SSM ${/orbit-foundation/dev-env/resources::PrivateSubnets}
-    IsolatedSubnets: !SSM ${/orbit-foundation/dev-env/resources::IsolatedSubnets}
+    VpcId: !SSM ${/orbit-f/dev-env/resources::VpcId}
+    PublicSubnets: !SSM ${/orbit-f/dev-env/resources::PublicSubnets}
+    PrivateSubnets: !SSM ${/orbit-f/dev-env/resources::PrivateSubnets}
+    IsolatedSubnets: !SSM ${/orbit-f/dev-env/resources::IsolatedSubnets}
     Data:
         InternetAccessible: !ENV ${INTERNET_ACCESSIBLE::false}
-        NodesSubnets: !SSM ${/orbit-foundation/dev-env/resources::NodesSubnets}
+        NodesSubnets: !SSM ${/orbit-f/dev-env/resources::NodesSubnets}
     Frontend:
-        LoadBalancersSubnets: !SSM ${/orbit-foundation/dev-env/resources::LoadBalancersSubnets}
-        SslCertArn: !SSM ${/orbit-foundation/dev-env/resources::SslCertArn}
+        LoadBalancersSubnets: !SSM ${/orbit-f/dev-env/resources::LoadBalancersSubnets}
+        SslCertArn: !SSM ${/orbit-f/dev-env/resources::SslCertArn}
 ManagedNodegroups:
 -   Name: primary-compute
     InstanceType: m5.2xlarge

--- a/samples/manifests/plugins/demo-lake-admin-cfn-template.yaml
+++ b/samples/manifests/plugins/demo-lake-admin-cfn-template.yaml
@@ -65,6 +65,8 @@ Resources:
         - ''
         - - 'orbit-'
           - !Ref envname
+          - '-'
+          - !Ref "AWS::Region"
           - '-demo-lake-admin-add-policy'
       Path: /
 

--- a/samples/manifests/plugins/demo-lake-user-cfn-template.yaml
+++ b/samples/manifests/plugins/demo-lake-user-cfn-template.yaml
@@ -112,6 +112,8 @@ Resources:
         - ''
         - - 'orbit-'
           - !Ref envname
+          - '-'
+          - !Ref "AWS::Region"
           - '-demo-lake-user-add-policy'
       Path: /
   LakeUserGroup:

--- a/samples/manifests/plugins/dev-env-single-team.yaml
+++ b/samples/manifests/plugins/dev-env-single-team.yaml
@@ -3,10 +3,10 @@ CodeartifactDomain: !ENV ${CODEARTIFACT_DOMAIN::}
 CodeartifactRepository: !ENV ${CODEARTIFACT_REPOSITORY::}
 EksSystemMastersRoles:
 -   !ENV ${ORBIT_ADMIN_ROLE::Admin}
-ScratchBucketArn: !SSM ${/orbit-foundation/dev-env/resources::ScratchBucketArn}
-UserPoolId: !SSM ${/orbit-foundation/dev-env/resources::UserPoolId}
-SharedEfsFsId: !SSM ${/orbit-foundation/dev-env/resources::SharedEfsFsId}
-SharedEfsSgId: !SSM ${/orbit-foundation/dev-env/resources::SharedEfsSgId}
+ScratchBucketArn: !SSM ${/orbit-f/dev-env/resources::ScratchBucketArn}
+UserPoolId: !SSM ${/orbit-f/dev-env/resources::UserPoolId}
+SharedEfsFsId: !SSM ${/orbit-f/dev-env/resources::SharedEfsFsId}
+SharedEfsSgId: !SSM ${/orbit-f/dev-env/resources::SharedEfsSgId}
 InstallSsmAgent: true
 CognitoExternalProvider: !ENV ${COGNITO_EXTERNAL_PROVIDER::}
 CognitoExternalProviderLabel: !ENV ${COGNITO_EXTERNAL_PROVIDER_LABEL::}
@@ -21,16 +21,16 @@ Images:
         Repository: !ENV ${UTILITY_DATA_REPO::public.ecr.aws/v3o4w1g6/aws-orbit-workbench/utility-data}
         Version: !ENV ${VERSION::latest}
 Networking:
-    VpcId: !SSM ${/orbit-foundation/dev-env/resources::VpcId}
-    PublicSubnets: !SSM ${/orbit-foundation/dev-env/resources::PublicSubnets}
-    PrivateSubnets: !SSM ${/orbit-foundation/dev-env/resources::PrivateSubnets}
-    IsolatedSubnets: !SSM ${/orbit-foundation/dev-env/resources::IsolatedSubnets}
+    VpcId: !SSM ${/orbit-f/dev-env/resources::VpcId}
+    PublicSubnets: !SSM ${/orbit-f/dev-env/resources::PublicSubnets}
+    PrivateSubnets: !SSM ${/orbit-f/dev-env/resources::PrivateSubnets}
+    IsolatedSubnets: !SSM ${/orbit-f/dev-env/resources::IsolatedSubnets}
     Data:
         InternetAccessible: !ENV ${INTERNET_ACCESSIBLE::false}
-        NodesSubnets: !SSM ${/orbit-foundation/dev-env/resources::NodesSubnets}
+        NodesSubnets: !SSM ${/orbit-f/dev-env/resources::NodesSubnets}
     Frontend:
-        LoadBalancersSubnets: !SSM ${/orbit-foundation/dev-env/resources::LoadBalancersSubnets}
-        SslCertArn: !SSM ${/orbit-foundation/dev-env/resources::SslCertArn}
+        LoadBalancersSubnets: !SSM ${/orbit-f/dev-env/resources::LoadBalancersSubnets}
+        SslCertArn: !SSM ${/orbit-f/dev-env/resources::SslCertArn}
 ManagedNodegroups:
 -   Name: primary-compute
     InstanceType: m5.2xlarge
@@ -49,7 +49,7 @@ ManagedNodegroups:
 Teams:
 -   Name: lake-creator
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-creator-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-creator-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: true
@@ -57,3 +57,5 @@ Teams:
     - 0.0.0.0/0
     Plugins: !include lake-creator-plugins.yaml
     EfsLifeCycle: AFTER_7_DAYS
+    AuthenticationGroups:
+    - lake-creator

--- a/samples/manifests/plugins/dev-env-with-plugins-isolated.yaml
+++ b/samples/manifests/plugins/dev-env-with-plugins-isolated.yaml
@@ -3,10 +3,10 @@ CodeartifactDomain: !ENV ${CODEARTIFACT_DOMAIN::}
 CodeartifactRepository: !ENV ${CODEARTIFACT_REPOSITORY::}
 EksSystemMastersRoles:
 -   !ENV ${ORBIT_ADMIN_ROLE::Admin}
-ScratchBucketArn: !SSM ${/orbit-foundation/dev-env-iso/resources::ScratchBucketArn}
-UserPoolId: !SSM ${/orbit-foundation/dev-env-iso/resources::UserPoolId}
-SharedEfsFsId: !SSM ${/orbit-foundation/dev-env-iso/resources::SharedEfsFsId}
-SharedEfsSgId: !SSM ${/orbit-foundation/dev-env-iso/resources::SharedEfsSgId}
+ScratchBucketArn: !SSM ${/orbit-f/dev-env-iso/resources::ScratchBucketArn}
+UserPoolId: !SSM ${/orbit-f/dev-env-iso/resources::UserPoolId}
+SharedEfsFsId: !SSM ${/orbit-f/dev-env-iso/resources::SharedEfsFsId}
+SharedEfsSgId: !SSM ${/orbit-f/dev-env-iso/resources::SharedEfsSgId}
 InstallSsmAgent: true
 CognitoExternalProvider: !ENV ${COGNITO_EXTERNAL_PROVIDER::}
 CognitoExternalProviderLabel: !ENV ${COGNITO_EXTERNAL_PROVIDER_LABEL::}
@@ -21,16 +21,16 @@ Images:
         Repository: !ENV ${UTILITY_DATA_REPO::public.ecr.aws/v3o4w1g6/aws-orbit-workbench/utility-data}
         Version: !ENV ${VERSION::latest}
 Networking:
-    VpcId: !SSM ${/orbit-foundation/dev-env-iso/resources::VpcId}
-    PublicSubnets: !SSM ${/orbit-foundation/dev-env-iso/resources::PublicSubnets}
-    PrivateSubnets: !SSM ${/orbit-foundation/dev-env-iso/resources::PrivateSubnets}
-    IsolatedSubnets: !SSM ${/orbit-foundation/dev-env-iso/resources::IsolatedSubnets}
+    VpcId: !SSM ${/orbit-f/dev-env-iso/resources::VpcId}
+    PublicSubnets: !SSM ${/orbit-f/dev-env-iso/resources::PublicSubnets}
+    PrivateSubnets: !SSM ${/orbit-f/dev-env-iso/resources::PrivateSubnets}
+    IsolatedSubnets: !SSM ${/orbit-f/dev-env-iso/resources::IsolatedSubnets}
     Data:
         InternetAccessible: !ENV ${INTERNET_ACCESSIBLE::false}
-        NodesSubnets: !SSM ${/orbit-foundation/dev-env-iso/resources::NodesSubnets}
+        NodesSubnets: !SSM ${/orbit-f/dev-env-iso/resources::NodesSubnets}
     Frontend:
-        LoadBalancersSubnets: !SSM ${/orbit-foundation/dev-env-iso/resources::LoadBalancersSubnets}
-        SslCertArn: !SSM ${/orbit-foundation/dev-env-iso/resources::SslCertArn}
+        LoadBalancersSubnets: !SSM ${/orbit-f/dev-env-iso/resources::LoadBalancersSubnets}
+        SslCertArn: !SSM ${/orbit-f/dev-env-iso/resources::SslCertArn}
 ManagedNodegroups:
 -   Name: primary-compute
     InstanceType: m5.2xlarge
@@ -49,7 +49,7 @@ ManagedNodegroups:
 Teams:
 -   Name: lake-admin
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-admin-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-admin-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: true
@@ -57,9 +57,11 @@ Teams:
     - 0.0.0.0/0
     Plugins: !include lake-admin-plugins.yaml
     EfsLifeCycle: AFTER_7_DAYS
+    AuthenticationGroups:
+    - lake-admin
 -   Name: lake-creator
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-creator-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-creator-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: false
@@ -67,12 +69,17 @@ Teams:
     - 0.0.0.0/0
     Plugins: !include lake-creator-plugins.yaml
     EfsLifeCycle: AFTER_7_DAYS
+    AuthenticationGroups:
+    - lake-creator
 -   Name: lake-user
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-user-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-user-add-policy
     JupyterhubInboundRanges:
     - 0.0.0.0/0
     GrantSudo: true
     Profiles: !include lake-user-profiles.json
     Plugins: !include lake-user-plugins.yaml
     EfsLifeCycle: AFTER_7_DAYS
+    AuthenticationGroups:
+    - lake-user
+

--- a/samples/manifests/plugins/dev-env-with-plugins-public.yaml
+++ b/samples/manifests/plugins/dev-env-with-plugins-public.yaml
@@ -3,22 +3,22 @@ CodeartifactDomain: !ENV ${CODEARTIFACT_DOMAIN::}
 CodeartifactRepository: !ENV ${CODEARTIFACT_REPOSITORY::}
 EksSystemMastersRoles:
 -   !ENV ${ORBIT_ADMIN_ROLE::Admin}
-ScratchBucketArn: !SSM ${/orbit-foundation/public2/resources::ScratchBucketArn}
-UserPoolId: !SSM ${/orbit-foundation/public2/resources::UserPoolId}
-SharedEfsFsId: !SSM ${/orbit-foundation/public2/resources::SharedEfsFsId}
-SharedEfsSgId: !SSM ${/orbit-foundation/public2/resources::SharedEfsSgId}
+ScratchBucketArn: !SSM ${/orbit-f/public2/resources::ScratchBucketArn}
+UserPoolId: !SSM ${/orbit-f/public2/resources::UserPoolId}
+SharedEfsFsId: !SSM ${/orbit-f/public2/resources::SharedEfsFsId}
+SharedEfsSgId: !SSM ${/orbit-f/public2/resources::SharedEfsSgId}
 InstallSsmAgent: true
 Networking:
-    VpcId: !SSM ${/orbit-foundation/public2/resources::VpcId}
-    PublicSubnets: !SSM ${/orbit-foundation/public2/resources::PublicSubnets}
-    PrivateSubnets: !SSM ${/orbit-foundation/public2/resources::PrivateSubnets}
-    IsolatedSubnets: !SSM ${/orbit-foundation/public2/resources::IsolatedSubnets}
+    VpcId: !SSM ${/orbit-f/public2/resources::VpcId}
+    PublicSubnets: !SSM ${/orbit-f/public2/resources::PublicSubnets}
+    PrivateSubnets: !SSM ${/orbit-f/public2/resources::PrivateSubnets}
+    IsolatedSubnets: !SSM ${/orbit-f/public2/resources::IsolatedSubnets}
     Data:
         InternetAccessible: !ENV ${INTERNET_ACCESSIBLE::false}
-        NodesSubnets: !SSM ${/orbit-foundation/public2/resources::NodesSubnets}
+        NodesSubnets: !SSM ${/orbit-f/public2/resources::NodesSubnets}
     Frontend:
-        LoadBalancersSubnets: !SSM ${/orbit-foundation/public2/resources::LoadBalancersSubnets}
-        SslCertArn: !SSM ${/orbit-foundation/public2/resources::SslCertArn}
+        LoadBalancersSubnets: !SSM ${/orbit-f/public2/resources::LoadBalancersSubnets}
+        SslCertArn: !SSM ${/orbit-f/public2/resources::SslCertArn}
 ManagedNodegroups:
 -   Name: primary-compute
     InstanceType: m5.2xlarge
@@ -31,7 +31,7 @@ ManagedNodegroups:
 Teams:
 -   Name: lake-admin
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::public2}-demo-lake-admin-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::public2}-${AWS_DEFAULT_REGION::}-demo-lake-admin-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: true
@@ -43,7 +43,7 @@ Teams:
     - lake-admin
 -   Name: lake-creator
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::public2}-demo-lake-creator-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::public2}-${AWS_DEFAULT_REGION::}-demo-lake-creator-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: true
@@ -55,7 +55,7 @@ Teams:
     - lake-creator
 -   Name: lake-user
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::public2}-demo-lake-user-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::public2}-${AWS_DEFAULT_REGION::}-demo-lake-user-add-policy
     JupyterhubInboundRanges:
     - 0.0.0.0/0
     GrantSudo: true

--- a/samples/manifests/plugins/dev-env-with-plugins.yaml
+++ b/samples/manifests/plugins/dev-env-with-plugins.yaml
@@ -3,10 +3,10 @@ CodeartifactDomain: !ENV ${CODEARTIFACT_DOMAIN::}
 CodeartifactRepository: !ENV ${CODEARTIFACT_REPOSITORY::}
 EksSystemMastersRoles:
 -   !ENV ${ORBIT_ADMIN_ROLE::Admin}
-ScratchBucketArn: !SSM ${/orbit-foundation/dev-env/resources::ScratchBucketArn}
-UserPoolId: !SSM ${/orbit-foundation/dev-env/resources::UserPoolId}
-SharedEfsFsId: !SSM ${/orbit-foundation/dev-env/resources::SharedEfsFsId}
-SharedEfsSgId: !SSM ${/orbit-foundation/dev-env/resources::SharedEfsSgId}
+ScratchBucketArn: !SSM ${/orbit-f/dev-env/resources::ScratchBucketArn}
+UserPoolId: !SSM ${/orbit-f/dev-env/resources::UserPoolId}
+SharedEfsFsId: !SSM ${/orbit-f/dev-env/resources::SharedEfsFsId}
+SharedEfsSgId: !SSM ${/orbit-f/dev-env/resources::SharedEfsSgId}
 InstallSsmAgent: true
 CognitoExternalProvider: !ENV ${COGNITO_EXTERNAL_PROVIDER::}
 CognitoExternalProviderLabel: !ENV ${COGNITO_EXTERNAL_PROVIDER_LABEL::}
@@ -21,16 +21,16 @@ Images:
         Repository: !ENV ${UTILITY_DATA_REPO::public.ecr.aws/v3o4w1g6/aws-orbit-workbench/utility-data}
         Version: !ENV ${VERSION::latest}
 Networking:
-    VpcId: !SSM ${/orbit-foundation/dev-env/resources::VpcId}
-    PublicSubnets: !SSM ${/orbit-foundation/dev-env/resources::PublicSubnets}
-    PrivateSubnets: !SSM ${/orbit-foundation/dev-env/resources::PrivateSubnets}
-    IsolatedSubnets: !SSM ${/orbit-foundation/dev-env/resources::IsolatedSubnets}
+    VpcId: !SSM ${/orbit-f/dev-env/resources::VpcId}
+    PublicSubnets: !SSM ${/orbit-f/dev-env/resources::PublicSubnets}
+    PrivateSubnets: !SSM ${/orbit-f/dev-env/resources::PrivateSubnets}
+    IsolatedSubnets: !SSM ${/orbit-f/dev-env/resources::IsolatedSubnets}
     Data:
         InternetAccessible: !ENV ${INTERNET_ACCESSIBLE::false}
-        NodesSubnets: !SSM ${/orbit-foundation/dev-env/resources::NodesSubnets}
+        NodesSubnets: !SSM ${/orbit-f/dev-env/resources::NodesSubnets}
     Frontend:
-        LoadBalancersSubnets: !SSM ${/orbit-foundation/dev-env/resources::LoadBalancersSubnets}
-        SslCertArn: !SSM ${/orbit-foundation/dev-env/resources::SslCertArn}
+        LoadBalancersSubnets: !SSM ${/orbit-f/dev-env/resources::LoadBalancersSubnets}
+        SslCertArn: !SSM ${/orbit-f/dev-env/resources::SslCertArn}
 ManagedNodegroups:
 -   Name: primary-compute
     InstanceType: m5.2xlarge
@@ -49,7 +49,7 @@ ManagedNodegroups:
 Teams:
 -   Name: lake-admin
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-admin-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-admin-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: true
@@ -61,7 +61,7 @@ Teams:
     - lake-admin
 -   Name: lake-creator
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-creator-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-creator-add-policy
     GrantSudo: true
     Fargate: false
     K8Admin: false
@@ -73,7 +73,7 @@ Teams:
     - lake-creator
 -   Name: lake-user
     Policies:
-    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-demo-lake-user-add-policy
+    - !ENV orbit-${ORBIT_ENV_NAME::dev-env}-${AWS_DEFAULT_REGION::}-demo-lake-user-add-policy
     JupyterhubInboundRanges:
     - 0.0.0.0/0
     GrantSudo: true

--- a/samples/manifests/plugins/dev-env-without-team.yaml
+++ b/samples/manifests/plugins/dev-env-without-team.yaml
@@ -3,10 +3,10 @@ CodeartifactDomain: !ENV ${CODEARTIFACT_DOMAIN::}
 CodeartifactRepository: !ENV ${CODEARTIFACT_REPOSITORY::}
 EksSystemMastersRoles:
 -   !ENV ${ORBIT_ADMIN_ROLE::Admin}
-ScratchBucketArn: !SSM ${/orbit-foundation/dev-env/resources::ScratchBucketArn}
-UserPoolId: !SSM ${/orbit-foundation/dev-env/resources::UserPoolId}
-SharedEfsFsId: !SSM ${/orbit-foundation/dev-env/resources::SharedEfsFsId}
-SharedEfsSgId: !SSM ${/orbit-foundation/dev-env/resources::SharedEfsSgId}
+ScratchBucketArn: !SSM ${/orbit-f/dev-env/resources::ScratchBucketArn}
+UserPoolId: !SSM ${/orbit-f/dev-env/resources::UserPoolId}
+SharedEfsFsId: !SSM ${/orbit-f/dev-env/resources::SharedEfsFsId}
+SharedEfsSgId: !SSM ${/orbit-f/dev-env/resources::SharedEfsSgId}
 InstallSsmAgent: true
 Images:
     JupyterUser:
@@ -19,15 +19,15 @@ Images:
         Repository: !ENV ${UTILITY_DATA_REPO::public.ecr.aws/v3o4w1g6/aws-orbit-workbench/utility-data}
         Version: !ENV ${VERSION::latest}
 Networking:
-    VpcId: !SSM ${/orbit-foundation/dev-env/resources::VpcId}
-    PublicSubnets: !SSM ${/orbit-foundation/dev-env/resources::PublicSubnets}
-    PrivateSubnets: !SSM ${/orbit-foundation/dev-env/resources::PrivateSubnets}
-    IsolatedSubnets: !SSM ${/orbit-foundation/dev-env/resources::IsolatedSubnets}
+    VpcId: !SSM ${/orbit-f/dev-env/resources::VpcId}
+    PublicSubnets: !SSM ${/orbit-f/dev-env/resources::PublicSubnets}
+    PrivateSubnets: !SSM ${/orbit-f/dev-env/resources::PrivateSubnets}
+    IsolatedSubnets: !SSM ${/orbit-f/dev-env/resources::IsolatedSubnets}
     Data:
         InternetAccessible: !ENV ${INTERNET_ACCESSIBLE::false}
-        NodesSubnets: !SSM ${/orbit-foundation/dev-env/resources::NodesSubnets}
+        NodesSubnets: !SSM ${/orbit-f/dev-env/resources::NodesSubnets}
     Frontend:
-        LoadBalancersSubnets: !SSM ${/orbit-foundation/dev-env/resources::LoadBalancersSubnets}
-        SslCertArn: !SSM ${/orbit-foundation/dev-env/resources::SslCertArn}
+        LoadBalancersSubnets: !SSM ${/orbit-f/dev-env/resources::LoadBalancersSubnets}
+        SslCertArn: !SSM ${/orbit-f/dev-env/resources::SslCertArn}
 ManagedNodegroups: []
 Teams: []

--- a/samples/notebooks/B-DataAnalyst/Example-1-SQL-Analysis-Athena.ipynb
+++ b/samples/notebooks/B-DataAnalyst/Example-1-SQL-Analysis-Athena.ipynb
@@ -179,7 +179,7 @@
        "   'PluginId': 'custom_cfn'}],\n",
        " 'Policies': ['orbit-dev-env-demo-lake-creator-add-policy'],\n",
        " 'Profiles': [],\n",
-       " 'ScratchBucket': 'orbit-foundation-dev-env-scratch-495869084367-77f116',\n",
+       " 'ScratchBucket': 'orbit-f-dev-env-scratch-495869084367-77f116',\n",
        " 'SsmParameterName': '/orbit/dev-env/teams/lake-creator/context',\n",
        " 'StackName': 'orbit-dev-env-lake-creator',\n",
        " 'TeamKmsKeyArn': 'arn:aws:kms:us-west-2:495869084367:key/3d9d481a-9146-4d97-b559-0a91e19c9d09',\n",


### PR DESCRIPTION
### Description:

1. Enabled AWS Orbit to be deployed to multiple regions within a single account. Made Global resources names (IAM roles, IAM policies, S3 buckets) regional.
2. Shortened `orbit-foundation` to `orbit-f` to solve the IAM role name size limit.

### Issue Reference URL

Fixes #755 
Fixes #870 

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
