### PR TITLE
Fix/overprovisioning plugin to run on node-groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: replace cert-manager/jobs with cert-manager/certifactes
 - FIX: remove the ownerReference on userspace PodDefaults (because they're in the teamspace namespace)
 - FIX: yaml parameter replacement regex
+- REFACTOR: modified overprovisioning plugin to leverage nodeSelector for application to nodeGroups
 
 ### **Removed**
 

--- a/plugins/overprovisioning/overprovisioning/__init__.py
+++ b/plugins/overprovisioning/overprovisioning/__init__.py
@@ -43,7 +43,7 @@ def deploy(
         parameters["cpu"] = "1"
 
     if "node_group" not in parameters:
-        raise Exception("The node-group is necessary to define where overprovisioning will run")
+        raise Exception(f"The parameter 'node_group' is missing for {plugin_id}...please add it")
 
     node_group = parameters["node_group"]
     del parameters["node_group"]

--- a/plugins/overprovisioning/overprovisioning/__init__.py
+++ b/plugins/overprovisioning/overprovisioning/__init__.py
@@ -42,9 +42,15 @@ def deploy(
     if "cpu" not in parameters:
         parameters["cpu"] = "1"
 
+    if "node_group" in parameters:
+        node_group = parameters["node_group"]
+        del parameters["node_group"]
+    else: 
+        node_group = "primary-compute"
+
     resources = {"resources": parameters}
 
-    _logger.info(f"overprovisioning installed with {containers} containers of profile:  {resources}.")
+    _logger.info(f"overprovisioning installed with {containers} containers of resources:  {resources}.")
 
     vars: Dict[str, Optional[str]] = dict(
         team=team_context.name,
@@ -56,6 +62,7 @@ def deploy(
         containers=containers,
         resources=yaml.dump(resources),
         toolkit_s3_bucket=context.toolkit.s3_bucket,
+        node_group=node_group,
     )
 
     repo = team_context.name

--- a/plugins/overprovisioning/overprovisioning/__init__.py
+++ b/plugins/overprovisioning/overprovisioning/__init__.py
@@ -42,11 +42,11 @@ def deploy(
     if "cpu" not in parameters:
         parameters["cpu"] = "1"
 
-    if "node_group" in parameters:
-        node_group = parameters["node_group"]
-        del parameters["node_group"]
-    else: 
-        node_group = "primary-compute"
+    if "node_group" not in parameters:
+        raise Exception("The node-group is necessary to define where overprovisioning will run")
+
+    node_group = parameters["node_group"]
+    del parameters["node_group"]
 
     resources = {"resources": parameters}
 

--- a/plugins/overprovisioning/overprovisioning/values.yaml
+++ b/plugins/overprovisioning/overprovisioning/values.yaml
@@ -16,14 +16,14 @@ replicas: ${containers}
 podAnnotations: {}
 restartPolicy: ${restart_policy}
 headLabels:
-  orbit/node-type: ec2
+  orbit/node-group: ${node_group}
   orbit/attach-security-group: "yes"
   app: "orbit-overprovisioning"
   component: overprovisioning-head
   type: overprovisioning
 
 workerLabels:
-  orbit/node-type: ec2
+  orbit/node-group: ${node_group}
   orbit/attach-security-group: "yes"
   app: "orbit-overprovisioning"
   component: overprovisioning-worker
@@ -31,6 +31,6 @@ workerLabels:
 
 nodeSelector:
   orbit/usage: teams
-  orbit/node-type: ec2
+  orbit/node-group: ${node_group}
 
 ${resources}

--- a/samples/manifests/plugins/lake-admin-plugins.yaml
+++ b/samples/manifests/plugins/lake-admin-plugins.yaml
@@ -25,3 +25,17 @@
         image: public.ecr.aws/v3o4w1g6/aws-orbit-workbench/utility-data:latest
         uid: 0
         gid: 0
+-   PluginId: overprovisioning-primary-compute
+    Module: overprovisioning
+    Parameters:
+        node_group: primary-compute
+        replicas: 3
+        cpu: 3
+        memory: 4G
+#-   PluginId: overprovisioning-primary-gpu
+#    Module: overprovisioning
+#    Parameters:
+#        node_group: primary-gpu
+#        replicas: 1
+#        gpu: 1
+#        memory: 5G 


### PR DESCRIPTION
### Description:

Refactor overprovisioning to support nodegroups in nodeSelector.  Re-implement on the admin namespace and have example for GPU nodegroups

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/646

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
