### PR TITLE
Adding fsx tagging access for PVC based PV creation dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: jupyter-webapp custom configmap
 - FIX: restart SSM Agent DaemonSet after image replication
 - UPDATED: python packages and dependencies
-
+- UPDATED: Fsx Lustre serviceaccount IAM role policy change to allow fsx resource tagging
 
 ### **Removed**
 -- REMOVED: call to install ~/.kube/config

--- a/cli/aws_orbit/remote_files/cdk/env.py
+++ b/cli/aws_orbit/remote_files/cdk/env.py
@@ -137,6 +137,7 @@ class Env(Stack):
                                 "fsx:CreateFileSystem",
                                 "fsx:DeleteFileSystem",
                                 "fsx:DescribeFileSystems",
+                                "fsx:TagResource"
                             ],
                             resources=["*"],
                         ),

--- a/cli/aws_orbit/remote_files/cdk/env.py
+++ b/cli/aws_orbit/remote_files/cdk/env.py
@@ -137,7 +137,7 @@ class Env(Stack):
                                 "fsx:CreateFileSystem",
                                 "fsx:DeleteFileSystem",
                                 "fsx:DescribeFileSystems",
-                                "fsx:TagResource"
+                                "fsx:TagResource",
                             ],
                             resources=["*"],
                         ),


### PR DESCRIPTION
### Description:

ServiceAccount IAM role needs access to perform: fsx:TagResource on resource: arn:aws:fsx:*:***:file-system/* to allow dynamic FSX based PV creation via PVC claim and StorageClass.

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR? #810 
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
