### PR TITLE
force alb-controller onto env nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: restart SSM Agent DaemonSet after image replication
 - UPDATED: python packages and dependencies
 - UPDATED: Fsx Lustre serviceaccount IAM role policy change to allow fsx resource tagging
+- FIX: force alb-controller in kubeflow to use env nodes
 
 ### **Removed**
 -- REMOVED: call to install ~/.kube/config

--- a/cli/aws_orbit/remote_files/kubectl.py
+++ b/cli/aws_orbit/remote_files/kubectl.py
@@ -638,6 +638,14 @@ def deploy_env(context: "Context") -> None:
             # sh.run(f"kubectl patch deployment -n orbit-system landing-page-service --type json --patch '{patch}'")
 
         # Confirm env Service Endpoints
+        # Patch the alb-controller specifically to run in the env nodegroup IF we do have internet access
+        if context.networking.data.internet_accessible:
+            _logger.debug("Orbit applying KubeFlow patch to ALB Controller with Internet Access")
+            patch = (
+                '{"spec":{"template":{"metadata":{"labels":{"orbit/node-type":"ec2"}},'
+                '"spec":{"nodeSelector":{"orbit/usage":"reserved","orbit/node-group": "env"}}}}}')
+            sh.run(f"kubectl patch deployment -n kubeflow alb-ingress-controller --patch '{patch}'")
+
         _confirm_endpoints(name="landing-page-service", namespace="orbit-system", k8s_context=k8s_context)
 
 

--- a/cli/aws_orbit/remote_files/kubectl.py
+++ b/cli/aws_orbit/remote_files/kubectl.py
@@ -643,7 +643,8 @@ def deploy_env(context: "Context") -> None:
             _logger.debug("Orbit applying KubeFlow patch to ALB Controller with Internet Access")
             patch = (
                 '{"spec":{"template":{"metadata":{"labels":{"orbit/node-type":"ec2"}},'
-                '"spec":{"nodeSelector":{"orbit/usage":"reserved","orbit/node-group": "env"}}}}}')
+                '"spec":{"nodeSelector":{"orbit/usage":"reserved","orbit/node-group": "env"}}}}}'
+            )
             sh.run(f"kubectl patch deployment -n kubeflow alb-ingress-controller --patch '{patch}'")
 
         _confirm_endpoints(name="landing-page-service", namespace="orbit-system", k8s_context=k8s_context)


### PR DESCRIPTION
### Description:

Force the al-controller to use env nodes via nodeSelector applied via a patch

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/896

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
