### PR TITLE
Removed region from bucket reference

### DIFF
--- a/plugins/custom_cfn/custom_cfn/__init__.py
+++ b/plugins/custom_cfn/custom_cfn/__init__.py
@@ -83,8 +83,8 @@ def destroy(
     stack_name = f"orbit-{context.name}-{team_context.name}-{plugin_id}-custom-demo-resources"
     _logger.debug(f"stack_name={stack_name}")
     bucket_names: Dict[str, Any] = {
-        "lake-bucket": f"orbit-{env_name}-{region}-demo-lake-{acct}-{deploy_id}",
-        "secured-lake-bucket": f"orbit-{env_name}-{region}-secured-demo-lake-{acct}-{deploy_id}",
+        "lake-bucket": f"orbit-{env_name}-demo-lake-{acct}-{deploy_id}",
+        "secured-lake-bucket": f"orbit-{env_name}-secured-demo-lake-{acct}-{deploy_id}",
     }
     _logger.debug(f"bucket_names={bucket_names}")
     # CDK skips bucket deletion.

--- a/plugins/custom_cfn/custom_cfn/__init__.py
+++ b/plugins/custom_cfn/custom_cfn/__init__.py
@@ -76,7 +76,6 @@ def destroy(
     )
     _logger.debug("Team Env name: %s | Team name: %s", context.name, team_context.name)
     env_name = context.name
-    region = context.region
     acct: str = context.account_id
     deploy_id: str = cast(str, context.toolkit.deploy_id)
     plugin_id = plugin_id.replace("_", "-")


### PR DESCRIPTION
Destroy teams references lake-buckets with region in the name. That doesnt exist, so redeployment of teams fails because the buckets exists because they were not destroyed in destroy teams
----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
