### PR TITLE
adding region from context when deploying teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - UPDATED: Fsx Lustre serviceaccount IAM role policy change to allow fsx resource tagging
 - FIX: force alb-controller in kubeflow to use env nodes
 - FIX: redshift plugin describe cluster based on specific env and team tags
+- FIX: added region to team when deploying plugins
 
 ### **Removed**
 -- REMOVED: call to install ~/.kube/config

--- a/cli/aws_orbit/remote_files/kubectl.py
+++ b/cli/aws_orbit/remote_files/kubectl.py
@@ -194,6 +194,7 @@ def _team(context: "Context", team_context: "TeamContext", output_path: str) -> 
             cluster_pod_security_group_id=context.cluster_pod_sg_id,
             team_context=ContextSerDe.dump_context_to_str(team_context),
             env_context=ContextSerDe.dump_context_to_str(context),
+            region=context.region,
         ),
     )
     _logger.debug("Kubectl Team %s manifest:\n%s", team_context.name, content)


### PR DESCRIPTION
### Description:

teams needed the region populated from the context

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/930

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
