### PR TITLE
Destroy cluster only related to the destroy's env

### DIFF
--- a/plugins/redshift/redshift/__init__.py
+++ b/plugins/redshift/redshift/__init__.py
@@ -67,9 +67,11 @@ def destroy(
         for cluster in clusters:
             cluster_id = cluster["ClusterIdentifier"]
             _logger.debug(f"cluster_id={cluster_id}")
-            cluster_name = cluster_id if namespace in cluster_id else namespace + cluster_id
-            redshift.delete_cluster(ClusterIdentifier=cluster_name, SkipFinalClusterSnapshot=True)
-            _logger.debug(f"Delete redshift cluster_name={cluster_name}")
+            _logger.debug(f"namespace={namespace}")
+            if namespace in cluster_id:
+                cluster_name = cluster_id
+                redshift.delete_cluster(ClusterIdentifier=cluster_name, SkipFinalClusterSnapshot=True)
+                _logger.debug(f"Delete redshift cluster_name={cluster_name}")
         # Hold before destroying the redshift plugin resource.
         time.sleep(180)
         _logger.debug(f"Deleted {team_context.name} team redshift clusters")


### PR DESCRIPTION
The destroy redshift function was trying to remove all clusters, even those outside of it's env. This caused it to look for clusters that didnt exist due to the namespaces of other env clusters

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
