### PR TITLE
Feature - Copy CodeCommit plugin based notebooks to scheduled container executions

### DIFF
--- a/images/jupyter-user/python-utils/notebook_runner.py
+++ b/images/jupyter-user/python-utils/notebook_runner.py
@@ -131,7 +131,7 @@ def prepareAndValidateNotebooks(default_output_directory, notebooks):
             if task["sourcePath"] and "codecommit::" in task["sourcePath"]
         ]
     )
-
+    logger.info(f"cc_repo_list={cc_repo_list}")
     # For each code repo, clone to specific repo name based folder.
     for cc_repo in cc_repo_list:
         repo_path = cc_repo.replace("::", f"::{cc_region}://")
@@ -166,6 +166,7 @@ def print_dir(dir: str, exclude: List[str] = []) -> None:
 
 
 def prepareNotebook(default_output_directory, notebook, key):
+    logger.info(f"prepareNotebook={notebook}")
     notebookName = notebook["notebookName"]
     sourcePath = notebook["sourcePath"]
     targetPath = notebook.get("targetPath", default_output_directory)

--- a/images/jupyter-user/python-utils/notebook_runner.py
+++ b/images/jupyter-user/python-utils/notebook_runner.py
@@ -21,6 +21,7 @@ from typing import List
 
 import papermill as pm
 import yaml as yaml
+from aws_orbit import sh
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -121,6 +122,24 @@ def runNotebook(parameters):
 
 
 def prepareAndValidateNotebooks(default_output_directory, notebooks):
+    cc_region = os.environ.get("AWS_DEFAULT_REGION")
+    # Get all git repos
+    cc_repo_list = set(
+        [
+            task["sourcePath"].split("/")[0]
+            for task in notebooks["tasks"]
+            if task["sourcePath"] and "codecommit::" in task["sourcePath"]
+        ]
+    )
+
+    # For each code repo, clone to specific repo name based folder.
+    for cc_repo in cc_repo_list:
+        repo_path = cc_repo.replace("::", f"::{cc_region}://")
+        repo_name = cc_repo.split("::")[-1]
+        logger.info(f"Cloning {repo_path}")
+        sh.run(f"git clone {repo_path} /tmp/{repo_name}/")
+        # sh.run(f"git clone codecommit::{cc_region}://orbit-iter-lake-user /tmp/{repo_name}/")
+
     reportsToRun = []
     id = 1
     for notebook in notebooks["tasks"]:
@@ -157,6 +176,10 @@ def prepareNotebook(default_output_directory, notebook, key):
 
     logger.debug(f"Source Path: {sourcePath}")
     sourcePath = sourcePath.replace("$ORBIT_TRANSFORMATION_NOTEBOOKS_ROOT", "/opt/transformations/")
+
+    # Check for codecommit and replace with temp path
+    sourcePath = sourcePath.replace("codecommit::", "/tmp/")
+
     workdir = os.path.abspath(sourcePath)
 
     pathToNotebook = os.path.join(sourcePath, notebookName)

--- a/images/jupyter-user/requirements.txt
+++ b/images/jupyter-user/requirements.txt
@@ -25,3 +25,4 @@ colorlover~=0.3.0
 plotly~=4.14.3
 scikit-learn~=0.24.1
 bokeh~=2.3.1
+git-remote-codecommit==1.15.1


### PR DESCRIPTION
### Description:

Feature allowing CodeCommit based files available to the job pod container file system. The CodeCommit repo is cloned to container /tmp/* path.

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
