### PR TITLE
fix/change logic in filtering repos to be destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: added suppprt for sql parameters in magics (ddl and create_external_table --- database.py)
 - FIX: added suppprt for  parameters in magics (run_notebooks and schedule_notebooks --- orbit.py)
 - FIX: Example-6-Schedule-Notebook, removed git:// reference
+- FIX: ecr repo filter logic used to delete existing env repos
 ### **Removed**
 - REMOVED: changes to team-script-launcher...filesystem is now always used
 - REMOVED: orbit profile support (use podsettings)

--- a/cli/aws_orbit/services/ecr.py
+++ b/cli/aws_orbit/services/ecr.py
@@ -21,8 +21,6 @@ def _filter_repos(env_name: str, page: Dict[str, Any]) -> Iterator[str]:
     for repo in page["repositories"]:
         if repo["repositoryName"].startswith(f"orbit-{env_name}/"):
             yield repo["repositoryName"]
-        #elif repo["repositoryName"].startswith(f"orbit-{env_name}-"):
-        #    yield repo["repositoryName"]
         else:
             response: Dict[str, Any] = client.list_tags_for_resource(resourceArn=repo["repositoryArn"])
             for tag in response["tags"]:

--- a/cli/aws_orbit/services/ecr.py
+++ b/cli/aws_orbit/services/ecr.py
@@ -21,8 +21,8 @@ def _filter_repos(env_name: str, page: Dict[str, Any]) -> Iterator[str]:
     for repo in page["repositories"]:
         if repo["repositoryName"].startswith(f"orbit-{env_name}/"):
             yield repo["repositoryName"]
-        elif repo["repositoryName"].startswith(f"orbit-{env_name}-"):
-            yield repo["repositoryName"]
+        #elif repo["repositoryName"].startswith(f"orbit-{env_name}-"):
+        #    yield repo["repositoryName"]
         else:
             response: Dict[str, Any] = client.list_tags_for_resource(resourceArn=repo["repositoryArn"])
             for tag in response["tags"]:


### PR DESCRIPTION
### Description:

Filtering logic of repos based on env when destroying is too greedy.  Ex: env of 'full' and 'full-iso' exist, deleting env 'full' will delete all of 'full-iso' ecr repos

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/946

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
