### PR TITLE
fixed the orbitjob to use the status object, and not job index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Added orbitjob-operator and CRD
 - Added schedule (cron string) to orbitjob CRD
+- Added monitoring to OrbitJob so pytest can evaluate the jobs execution
 
 ### **Changed**
-
+- Moved away from Job index to Status object of K8s job to report the current status
 
 ### **Removed**
 


### PR DESCRIPTION
### Description:

fixed the orbitjob to use the status object, and not job index

### Issue Reference URL

#1064 

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
