### PR TITLE
Due to missing patch number, pip tried to install latest minor version

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -40,7 +40,7 @@ setup(
     keywords=["aws", "cdk"],
     python_requires=">=3.7, <3.9",
     install_requires=[
-        "boto3~=1.18",
+        "boto3~=1.18.0",
         "botocore~=1.15",
         "PyYAML~=5.4",
         "click~=7.1.0",


### PR DESCRIPTION
And therefore the latest boto3 minor version from the cli was causing installation issues with other dependencies 

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
