### PR TITLE
Fix team destroy fail to add repo uninit

### DIFF
--- a/plugins/team_script_launcher/team_script_launcher/__init__.py
+++ b/plugins/team_script_launcher/team_script_launcher/__init__.py
@@ -162,7 +162,7 @@ def destroy(
     helm.uninstall_chart(release_name, namespace=team_context.name)
 
 
-def _init_team_repo(context: "Context", team_context: "TeamContext", repo_location: str) -> str:
+def _init_team_repo(context: "Context", team_context: "TeamContext", repo_location: str) -> None:
     if not s3.object_exists(
         bucket=cast(str, context.toolkit.s3_bucket), key=f"helm/repositories/teams/{team_context.name}/index.yaml"
     ):
@@ -170,8 +170,6 @@ def _init_team_repo(context: "Context", team_context: "TeamContext", repo_locati
         sh.run(f"helm s3 init {repo_location}")
     else:
         _logger.debug("Skipping initialization of existing Team Helm Repository at %s", repo_location)
-
-    return repo_location
 
 
 def ns_exists(team_context: "TeamContext") -> bool:


### PR DESCRIPTION
### Description:
Skip attempt to deploy chart into namespace when the namespace doesnt exist

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
