### PR TITLE
FIX - logic for updating SSM when building images via multithreading

### DIFF
--- a/cli/aws_orbit/remote_files/deploy.py
+++ b/cli/aws_orbit/remote_files/deploy.py
@@ -395,8 +395,11 @@ def deploy_images_remotely_v2(env: str, requested_image: Optional[str] = None) -
                 new_images_manifest[im] = ImageManifest(repository=res[1], version=res[2])  # type: ignore
 
     _logger.debug(new_images_manifest)
-    context.images = ImagesManifest(**new_images_manifest)  # type: ignore
-    ContextSerDe.dump_context_to_ssm(context=context)
+    # Because this is multihreaded, we need to make sure we have the MOST UP TO DATE context
+    # So, fetch it again and rewrite...
+    context_latest: "Context" = ContextSerDe.load_context_from_ssm(env_name=env, type=Context)
+    context_latest.images = ImagesManifest(**new_images_manifest)  # type: ignore
+    ContextSerDe.dump_context_to_ssm(context=context_latest)
 
 
 def deploy_user_image_v2(


### PR DESCRIPTION
### Description:

When images are built, it is multithreaded AND supports building a single image at a time.  We need to make sure the thread / context is properly updated with the latest SSM info BEFORE writing changes back

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/TO_BE_DEFINED

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
