### PR TITLE
fix/remove cluster OIDC from admin trust when deleting env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: missing image ref in the README
 - FIX: updated Images block in manifest - no longer referencing public ECR as default
 - FIX: orbit build images funnction to update SSM on build  
+- FIX: deleted OIDC reference to trust policy of Admin when cluster is deleted
 
 ### **Removed**
 - REMOVED software-toolkit / slrt / remotectl

--- a/cli/aws_orbit/remote_files/eksctl.py
+++ b/cli/aws_orbit/remote_files/eksctl.py
@@ -579,7 +579,7 @@ def destroy_env(context: "Context") -> None:
                 "Action": "sts:AssumeRoleWithWebIdentity",
                 "Condition": {
                     "StringLike": {
-                        f"{context.eks_oidc_provider}:sub": f"system:serviceaccount:orbit-system:orbit-{context.name}-admin"
+                        f"{context.eks_oidc_provider}:sub": f"system:serviceaccount:orbit-system:orbit-{context.name}-admin"  # noqa
                     }
                 },
             },

--- a/cli/aws_orbit/services/iam.py
+++ b/cli/aws_orbit/services/iam.py
@@ -108,3 +108,24 @@ def add_assume_role_statement(role_name: str, statement: Dict[str, Any]) -> None
         policy_body = json.dumps(assume_role_policy)
         _logger.debug("policy_body: %s", policy_body)
         iam_client.update_assume_role_policy(RoleName=role_name, PolicyDocument=policy_body)
+
+
+def remove_assume_role_statement(role_name: str, statement: Dict[str, Any]) -> None:
+    _logger.debug(f"Removing AssumeRolePolicy for {role_name}, Removing: {statement}")
+
+    iam_client = boto3_client("iam")
+    assume_role_policy = iam_client.get_role(RoleName=role_name)["Role"]["AssumeRolePolicyDocument"]
+    statements = assume_role_policy["Statement"]
+
+    if statement in statements:
+        try:
+            _logger.debug("Statement found in AssumeRolePolicy .. removing")
+            statements.remove(statement)
+            assume_role_policy["Statement"] = statements
+            policy_body = json.dumps(assume_role_policy)
+            _logger.debug("policy_body: %s", policy_body)
+            iam_client.update_assume_role_policy(RoleName=role_name, PolicyDocument=policy_body)
+        except iam_client.exceptions.NoSuchEntityException:
+            _logger.error(f"Issues with finding the role....moving on")
+    else:
+        _logger.debug("Statement not found in policy, moving on")

--- a/cli/aws_orbit/services/iam.py
+++ b/cli/aws_orbit/services/iam.py
@@ -126,6 +126,6 @@ def remove_assume_role_statement(role_name: str, statement: Dict[str, Any]) -> N
             _logger.debug("policy_body: %s", policy_body)
             iam_client.update_assume_role_policy(RoleName=role_name, PolicyDocument=policy_body)
         except iam_client.exceptions.NoSuchEntityException:
-            _logger.error(f"Issues with finding the role....moving on")
+            _logger.error("Issues with finding the role....moving on")
     else:
         _logger.debug("Statement not found in policy, moving on")


### PR DESCRIPTION
### Description:

When destroying the env, delete the OIDC from the trust policy (that the toolkit manages) so that we don't hit the limit of the policy

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/1288

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
