### PR TITLE
Fix/lake creator zip extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: moved changeset from SSM to S3 to support larger number of teams
 - FIX: increased default codebuild timout
 - FIX: modified SSM to support deleting more than 10 teams at once 
-
+- FIX: updated papermill to 2.3.4 in jupyter-user to fix inabilty to run lake-creator tests
 ### **Removed**
 
 

--- a/images/jupyter-user/requirements.txt
+++ b/images/jupyter-user/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.17.87
 awscli==1.19.88
 jupyterlab==3.0.10
 jupyterhub==1.3.0
-papermill==2.3.2
+papermill==2.3.4
 nbconvert==6.0.7
 ipywidgets==7.6.3
 ipython-sql==0.4.0


### PR DESCRIPTION
### Description:

Lake-Creator regression tests were failing due to library inconsistency in papermill and click....update the papermill version..

REF:
```
INFO:papermill:Working directory: /home/jovyan/shared/samples/notebooks/A-LakeCreator
ERROR:root:Error during notebook execution: cannot import name 'ParameterSource' from 'click.core' (/opt/conda/lib/python3.8/site-packages/click/core.py)
```
