### PR TITLE
adding dynamic selection of xgboost image based on region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### **Changed**
 - FIX: added sm-operator plugin ability to pull region-specifc sm images
-- FIX: updated sm-operator notebook regression test
+- FIX: updated sm-operator notebook regression test - data parsing
+- FIX: updated sm-operator notebook to fetch xgboost image based off region
 
 ### **Removed**
 

--- a/samples/notebooks/H-Model-Development/Example-5-SageMaker-on-EKS-xgboost_mnist.ipynb
+++ b/samples/notebooks/H-Model-Development/Example-5-SageMaker-on-EKS-xgboost_mnist.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b465dcdc",
+   "id": "97cdac18",
    "metadata": {
     "papermill": {
      "duration": 0.130841,
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc8719f7",
+   "id": "c4d72d65",
    "metadata": {
     "isConfigCell": true,
     "papermill": {
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2587c43",
+   "id": "1b7582f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21590bbc",
+   "id": "969c5d28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be7a7b1b",
+   "id": "573c6196",
    "metadata": {
     "papermill": {
      "duration": 0.213617,
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9cc26f6",
+   "id": "79e729b4",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -168,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d71b039c",
+   "id": "74a5e567",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40d2f065",
+   "id": "cfbe8067",
    "metadata": {
     "isConfigCell": true,
     "papermill": {
@@ -209,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1aa1d20",
+   "id": "233f237a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0505ebcc",
+   "id": "504241cc",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -240,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e24d51e",
+   "id": "649e3e68",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37a0416c",
+   "id": "fc192768",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -280,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c2c2164",
+   "id": "deb3b087",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd860a9c",
+   "id": "a16b8cb3",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -318,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87356939",
+   "id": "badaf9cc",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -386,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf5920ba",
+   "id": "74a50462",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -407,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "805c02f0",
+   "id": "c9be1b28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +430,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f87a3a0c",
+   "id": "88999680",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "import json\n",
+    "\n",
+    "builtin_container_uri = get_image_uri(region_name=region,\n",
+    "                                     repo_name='xgboost',\n",
+    "                                     repo_version='1.2-1')\n",
+    "builtin_container_uri"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a49a9aad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +458,7 @@
     "  roleArn: {role}  \n",
     "  region: {region}\n",
     "  algorithmSpecification:\n",
-    "    trainingImage: 433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:latest\n",
+    "    trainingImage: {builtin_container_uri}\n",
     "    trainingInputMode: File\n",
     "  outputDataConfig:\n",
     "    s3OutputPath: {output_bucket}\n",
@@ -476,8 +492,6 @@
     "      value: \"4\"\n",
     "    - name: min_child_weight\n",
     "      value: \"6\"\n",
-    "    - name: silent\n",
-    "      value: \"0\"\n",
     "    - name: objective\n",
     "      value: multi:softmax\n",
     "    - name: num_class\n",
@@ -491,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efb7b054",
+   "id": "d4d49cb9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7b8ceec",
+   "id": "99ac7643",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "767831d7",
+   "id": "506d1762",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "034fc4dd",
+   "id": "29cc2add",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +567,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04b225d0",
+   "id": "d5f88733",
    "metadata": {},
    "source": [
     "## Lets look at the SMLogs\n",
@@ -564,7 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78cb7ca3",
+   "id": "d00051d5",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
### Description:

Fetch XGBoost image based off region from sagemaker utilities

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/1312

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
