### PR TITLE
putting dev requirements in proper place

### DIFF
--- a/images/jupyter-user/requirements-dev.txt
+++ b/images/jupyter-user/requirements-dev.txt
@@ -2,7 +2,7 @@ isort~=5.7.0
 black~=20.8b1
 flake8~=3.8.4
 mypy~=0.812
-cookiecutter~=1.7.2
+cookiecutter~=2.1.1
 tornado==6.1
 types-PyYAML~=0.1.6
 -r "requirements.txt"

--- a/images/jupyter-user/requirements.txt
+++ b/images/jupyter-user/requirements.txt
@@ -26,4 +26,3 @@ plotly~=4.14.3
 scikit-learn~=0.24.1
 bokeh~=2.3.1
 git-remote-codecommit==1.15.1
-cookiecutter~=2.1.1


### PR DESCRIPTION
### Description:

the dependabot issue version for cookiecutter should be in requrements-dev, not requirements

