### PR TITLE
ISSUE-1330: version lock jsii and constructs in remote-requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: added sm-operator plugin ability to pull region-specifc sm images
 - FIX: updated sm-operator notebook regression test - data parsing
 - FIX: updated sm-operator notebook to fetch xgboost image based off region
+- FIX: version locked jsii and constructs libraries in remote-requirements.txt to address CDK hang
 
 ### **Removed**
 

--- a/cli/remote-requirements.txt
+++ b/cli/remote-requirements.txt
@@ -55,3 +55,5 @@ aws-cdk.cx-api~=1.100.0
 aws-cdk.lambda-layer-awscli~=1.100.0
 aws-cdk.lambda-layer-kubectl~=1.100.0
 aws-cdk.region-info~=1.100.0
+constructs~=3.3.161
+jsii~=1.42.0


### PR DESCRIPTION
### Description:

version lock the **jsii** and **constructs** libraries in `cli/remote-requirements.txt` to eliminate cdk hang.

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/1330

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a ISSUE associated with this PR?
- [x] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
