### PR TITLE
add a node-group to sample manifest created by init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: updated sm-operator notebook regression test - data parsing
 - FIX: updated sm-operator notebook to fetch xgboost image based off region
 - FIX: version locked jsii and constructs libraries in remote-requirements.txt to address CDK hang
+- FIX: sample manifest from init command missing a compute node-group
 
 ### **Removed**
 

--- a/cli/aws_orbit/data/init/default-env-manifest.yaml
+++ b/cli/aws_orbit/data/init/default-env-manifest.yaml
@@ -24,6 +24,15 @@ Images:
     UtilityData:
         Repository: ${account_id}.dkr.ecr.${region}.amazonaws.com/orbit-${name}/utility-data
         Version: latest
+ManagedNodegroups:
+-   Name: primary-compute
+    InstanceType: m5.2xlarge
+    LocalStorageSize: 128
+    NodesNumDesired: 1
+    NodesNumMax: 4
+    NodesNumMin: 0
+    Labels:
+        instance-type: m5.2xlarge
 Teams:
 -   Name: sample-admin
     Policies:


### PR DESCRIPTION
### Description:

`orbit init` command creates a manifest that's missing a default compute node group. this PR adds a node-group called **primary-compute** as an example, with autoscaling to 0

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/<NUMBER>

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
