### PR TITLE
ISSUE-1335: Fix/missing ssm agent check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: updated sm-operator notebook regression test - data parsing
 - FIX: updated sm-operator notebook to fetch xgboost image based off region
 - FIX: version locked jsii and constructs libraries in remote-requirements.txt to address CDK hang
+- FIX: sample manifest from init command missing a compute node-group
 
 ### **Removed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: updated sm-operator notebook to fetch xgboost image based off region
 - FIX: version locked jsii and constructs libraries in remote-requirements.txt to address CDK hang
 - FIX: sample manifest from init command missing a compute node-group
-- FIX: fail to check for ssm-agent installation when deploying in isolated subnets
-- FIX: sample manifest from init command missing InstallSsmAgent: true recommendation
 
 ### **Removed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - FIX: updated sm-operator notebook to fetch xgboost image based off region
 - FIX: version locked jsii and constructs libraries in remote-requirements.txt to address CDK hang
 - FIX: sample manifest from init command missing a compute node-group
+- FIX: fail to check for ssm-agent installation when deploying in isolated subnets
+- FIX: sample manifest from init command missing InstallSsmAgent: true recommendation
 
 ### **Removed**
 

--- a/cli/aws_orbit/data/init/default-env-manifest.yaml
+++ b/cli/aws_orbit/data/init/default-env-manifest.yaml
@@ -3,6 +3,7 @@ ScratchBucketArn: !SSM ${/orbit-f/${name}/resources::ScratchBucketArn}
 UserPoolId: !SSM ${/orbit-f/${name}/resources::UserPoolId}
 SharedEfsFsId: !SSM ${/orbit-f/${name}/resources::SharedEfsFsId}
 SharedEfsSgId: !SSM ${/orbit-f/${name}/resources::SharedEfsSgId}
+InstallSsmAgent: true
 Networking:
     VpcId: !SSM ${/orbit-f/${name}/resources::VpcId}
     PublicSubnets: !SSM ${/orbit-f/${name}/resources::PublicSubnets}

--- a/cli/aws_orbit/data/init/default-env-manifest.yaml
+++ b/cli/aws_orbit/data/init/default-env-manifest.yaml
@@ -24,6 +24,15 @@ Images:
     UtilityData:
         Repository: ${account_id}.dkr.ecr.${region}.amazonaws.com/orbit-${name}/utility-data
         Version: latest
+ManagedNodegroups:
+-   Name: primary-compute
+    InstanceType: m5.2xlarge
+    LocalStorageSize: 128
+    NodesNumDesired: 1
+    NodesNumMax: 4
+    NodesNumMin: 0
+    Labels:
+        instance-type: m5.2xlarge
 Teams:
 -   Name: sample-admin
     Policies:

--- a/cli/aws_orbit/remote_files/kubectl.py
+++ b/cli/aws_orbit/remote_files/kubectl.py
@@ -645,10 +645,11 @@ def deploy_env(context: "Context") -> None:
                 name="imagereplication-operator", namespace="orbit-system", type="deployment", k8s_context=k8s_context
             )
             _confirm_endpoints(name="imagereplication-pod-webhook", namespace="orbit-system", k8s_context=k8s_context)
-            sh.run(
-                "kubectl rollout restart daemonsets -n orbit-system-ssm-daemons "
-                f"ssm-agent-installer --context {k8s_context}"
-            )
+            if context.install_ssm_agent:
+                sh.run(
+                    "kubectl rollout restart daemonsets -n orbit-system-ssm-daemons "
+                    f"ssm-agent-installer --context {k8s_context}"
+                )
 
         # kube-system kustomizations
         output_paths = _generate_kube_system_kustomizations(context=context)


### PR DESCRIPTION
### Description:

When deploying in an isolated environment, deployment failed to check if the SSM Agent was installed before restarting the SSM Agent DaemonSet. Added check and added `InstallSsmAgent: true` to init manifest as a best practice recommendation.

### Issue Reference URL

https://github.com/awslabs/aws-orbit-workbench/issues/1335

----------
### Do not change content below. Mark applicable check boxes only.

Thank you for submitting a contribution to AWS Orbit Workbench.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a ISSUE associated with this PR?
- [ ] Does your PR title start with ISSUE-XXXX where XXXX is the issue number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically 'main')?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under Apache License 2.0? 
